### PR TITLE
Prevent XSS attacks

### DIFF
--- a/tests/test_awss3.py
+++ b/tests/test_awss3.py
@@ -286,7 +286,7 @@ def test_list_objects_error(app):
     with TestClient(app) as client:
         response = client.get(f"/janelia-data-examples?list-type=2&max-keys=aaa")
         assert response.status_code == 400
-        assert response.headers['content-type'] == "application/json"
+        assert response.headers['content-type'] == "application/xml"
 
 
 def test_get_object_precedence(app):

--- a/tests/test_xss_prevention.py
+++ b/tests/test_xss_prevention.py
@@ -1,0 +1,176 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from x2s3.app import create_app
+from x2s3.settings import Settings
+from x2s3.utils import (
+    get_nosuchkey_response,
+    get_nosuchbucket_response, 
+    get_error_response,
+    parse_xml
+)
+
+
+class TestXSSPrevention:
+    """Test cases to ensure HTML/XML special characters are properly escaped in XML responses."""
+
+    def test_nosuchkey_response_escapes_html_brackets(self):
+        """Test that get_nosuchkey_response escapes HTML brackets in key names."""
+        malicious_key = '<script>alert("XSS")</script>'
+        response = get_nosuchkey_response(malicious_key)
+        
+        # Response should not contain unescaped brackets
+        content = response.body.decode()
+        assert '<script>' not in content
+        assert '</script>' not in content
+        
+        # Should contain escaped versions
+        assert '&lt;script&gt;' in content
+        assert '&lt;/script&gt;' in content
+        
+        # Should be valid XML
+        root = parse_xml(content)
+        assert root.find('Key').text == malicious_key
+
+    def test_nosuchkey_response_escapes_ampersands(self):
+        """Test that ampersands are properly escaped."""
+        malicious_key = 'test&value&more'
+        response = get_nosuchkey_response(malicious_key)
+        
+        content = response.body.decode()
+        # Should contain escaped ampersands
+        assert '&amp;' in content
+        # Should not contain unescaped ampersands (except in escape sequences)
+        unescaped_amps = content.replace('&amp;', '').replace('&lt;', '').replace('&gt;', '').replace('&quot;', '').replace('&apos;', '')
+        assert '&' not in unescaped_amps
+
+    def test_nosuchbucket_response_escapes_html_brackets(self):
+        """Test that get_nosuchbucket_response escapes HTML brackets in bucket names."""
+        malicious_bucket = '<img src=x onerror=alert("XSS")>'
+        response = get_nosuchbucket_response(malicious_bucket)
+        
+        content = response.body.decode()
+        assert '<img' not in content
+        # Note: HTML escaping converts quotes to &quot; so onerror= becomes onerror=
+        # The key test is that < and > are escaped
+        assert '&lt;img' in content
+        assert '&gt;' in content
+        
+        # Should be valid XML
+        root = parse_xml(content)
+        assert root.find('BucketName').text == malicious_bucket
+
+    def test_error_response_escapes_all_parameters(self):
+        """Test that get_error_response escapes all user-provided parameters."""
+        malicious_code = '<script>alert("code")</script>'
+        malicious_message = '</Message><script>alert("msg")</script><Message>'
+        malicious_resource = '<iframe src="javascript:alert(1)"></iframe>'
+        
+        response = get_error_response(400, malicious_code, malicious_message, malicious_resource)
+        
+        content = response.body.decode()
+        
+        # None of the malicious content should be unescaped
+        assert '<script>' not in content
+        assert '</script>' not in content  
+        assert '<iframe' not in content
+        assert '</Message><script>' not in content
+        # Note: javascript: is OK in escaped content as &quot;javascript:alert(1)&quot;
+        # The key is that the dangerous tags are escaped
+        
+        # Should contain properly escaped versions
+        assert '&lt;script&gt;' in content
+        assert '&lt;/script&gt;' in content
+        assert '&lt;iframe' in content
+        
+        # Should be valid XML
+        root = parse_xml(content)
+        assert root.find('Code').text == malicious_code
+        assert root.find('Message').text == malicious_message
+        assert root.find('Resource').text == malicious_resource
+
+    def test_quotes_are_escaped_in_xml_responses(self):
+        """Test that quotes are properly escaped in XML responses."""
+        key_with_quotes = 'test"value\'more'
+        response = get_nosuchkey_response(key_with_quotes)
+        
+        content = response.body.decode()
+        # Should be valid XML even with quotes
+        root = parse_xml(content)
+        assert root.find('Key').text == key_with_quotes
+
+
+    def test_direct_xss_injection_in_bucket_name(self):
+        """Test XSS injection directly through function calls with bucket names."""
+        malicious_bucket = '<script>alert("XSS")</script>'
+        response = get_nosuchbucket_response(malicious_bucket)
+        
+        content = response.body.decode()
+        assert '<script>' not in content
+        assert '&lt;script&gt;' in content
+
+    def test_direct_xss_injection_in_error_messages(self):
+        """Test XSS injection directly through function calls with error data."""
+        malicious_error = '<img src=x onerror=alert(1)>'
+        response = get_error_response(400, 'TestError', malicious_error, '/test')
+        
+        content = response.body.decode()
+        assert '<img' not in content
+        assert '&lt;img' in content
+
+    def test_complex_xml_injection_attempt(self):
+        """Test complex XML injection attempts are properly escaped."""
+        # Attempt to inject additional XML elements
+        malicious_input = '</Key><Script>alert("XSS")</Script><Key>'
+        
+        response = get_nosuchkey_response(malicious_input)
+        content = response.body.decode()
+        
+        # Should not create additional XML elements
+        assert '<script>' not in content.lower()
+        assert '</script>' not in content.lower()
+        
+        # Should be properly escaped
+        assert '&lt;/key&gt;' in content.lower()
+        assert '&lt;script&gt;' in content.lower()
+        
+        # XML should still be well-formed with only expected structure
+        root = parse_xml(content)
+        assert len(root.findall('.//Key')) == 1  # Should only have one Key element
+        assert root.find('Key').text == malicious_input
+
+    def test_unicode_and_special_characters(self):
+        """Test that unicode and special characters are handled safely."""
+        # Only test with valid XML characters - XML 1.0 doesn't allow control chars
+        unicode_chars = 'test\u2603\U0001F600'  # snowman and smiley emoji
+        
+        # This should not cause XML parsing errors
+        response = get_nosuchkey_response(unicode_chars)
+        
+        # Should produce valid XML
+        content = response.body.decode()
+        
+        # Should be parseable as XML
+        root = parse_xml(content)
+        
+        # Unicode should be preserved
+        assert root.find('Key').text == unicode_chars
+
+    def test_xml_control_characters_are_handled(self):
+        """Test that XML control characters don't break responses."""
+        special_chars = 'test\ttab\nnewline\rcarriage'  # Valid XML whitespace chars
+        
+        response = get_nosuchkey_response(special_chars)
+        content = response.body.decode()
+        
+        # Remove leading whitespace that inspect.cleandoc might add
+        content = content.strip()
+        
+        # Should be parseable as XML
+        root = parse_xml(content)
+        # XML normalizes whitespace in text content, so just check that it parses and contains the key
+        key_text = root.find('Key').text
+        assert 'test' in key_text
+        assert 'tab' in key_text
+        assert 'newline' in key_text
+        assert 'carriage' in key_text

--- a/x2s3/app.py
+++ b/x2s3/app.py
@@ -32,12 +32,11 @@ def create_app(settings):
 
     @app.exception_handler(StarletteHTTPException)
     async def http_exception_handler(request, exc):
-        return JSONResponse({"error":str(exc.detail)}, status_code=exc.status_code)
-
+        return get_error_response(exc.status_code, 'InternalError', exc.detail, request.url.path)
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(request, exc):
-        return JSONResponse({"error":str(exc)}, status_code=400)
+        return get_error_response(400, 'InvalidArgument', exc.detail, request.url.path)
 
 
     @app.on_event("startup")

--- a/x2s3/app.py
+++ b/x2s3/app.py
@@ -36,7 +36,8 @@ def create_app(settings):
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(request, exc):
-        return get_error_response(400, 'InvalidArgument', exc.detail, request.url.path)
+        error = exc.errors()[0]
+        return get_error_response(400, 'InvalidArgument', error['msg'], request.url.path)
 
 
     @app.on_event("startup")

--- a/x2s3/client_aioboto.py
+++ b/x2s3/client_aioboto.py
@@ -26,7 +26,7 @@ def handle_s3_exception(e, key=None):
         status_code = e.response['ResponseMetadata']['HTTPStatusCode']
         error = e.response['Error']
         error_code = error['Code'] if 'Code' in error else 'Unknown'
-        if error_code == "NoSuchKey":
+        if error_code == "NoSuchKey" or error_code == "404":
             return get_nosuchkey_response(key)
         else:
             message = error['Message'] if 'Message' in error else 'Unknown'

--- a/x2s3/utils.py
+++ b/x2s3/utils.py
@@ -3,6 +3,7 @@ import urllib
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from mimetypes import guess_type
+from html import escape
 
 from loguru import logger
 from dateutil import parser
@@ -157,7 +158,7 @@ def get_nosuchkey_response(key):
         <Error>
             <Code>NoSuchKey</Code>
             <Message>The specified key does not exist.</Message>
-            <Key>{key}</Key>
+            <Key>{escape(key)}</Key>
         </Error>
         """), status_code=404, media_type="application/xml")
 
@@ -168,7 +169,7 @@ def get_nosuchbucket_response(bucket_name):
         <Error>
             <Code>NoSuchBucket</Code>
             <Message>The specified bucket does not exist</Message>
-            <BucketName>{bucket_name}</BucketName>
+            <BucketName>{escape(bucket_name)}</BucketName>
         </Error>
         """), status_code=404, media_type="application/xml")
 
@@ -187,9 +188,9 @@ def get_error_response(status_code, error_code, message, resource):
     return Response(content=inspect.cleandoc(f"""
         <?xml version="1.0" encoding="UTF-8"?>
         <Error>
-            <Code>{error_code}</Code>
-            <Message>{message}</Message>
-            <Resource>{resource}</Resource>
+            <Code>{escape(error_code)}</Code>
+            <Message>{escape(message)}</Message>
+            <Resource>{escape(resource)}</Resource>
         </Error>
         """),
         status_code=status_code,


### PR DESCRIPTION
Pen testing found that it's possible to trigger the browser to run user input Javascript when accessing the XML API directly in the browser, for example:
https://s3proxy.janelia.org/fib-sem-technology/%3Cscript%20xmlns=%22http://www.w3.org/1999/xhtml%22%3Ealert(document.location)%3C/script%3E

This PR prevents these attacks by escaping user input when rendering output XML. I also added unit tests to ensure these problems don't reoccur. 

In addition to addressing XSS, I made sure all error responses return as XML (a few were returning as JSON).  

@StephanPreibisch @neomorphic @cgoina 
