### PR TITLE
Implemented range reads for the FileProxyClient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ platforms = ["osx-arm64", "osx-64", "linux-64"]
 
 [tool.pixi.tasks]
 dev-install = "pip install -e ."
-dev-launch = "uvicorn x2s3.app:app --host 0.0.0.0 --port 8000 --workers 1 --access-log --reload"
+dev-launch = "uvicorn x2s3.app:app --port 8000 --access-log --reload"
+dev-launch-remote = "uvicorn x2s3.app:app --host 0.0.0.0 --port 8000 --access-log --reload  --ssl-keyfile /opt/certs/cert.key --ssl-certfile /opt/certs/cert.crt"
 
 [tool.pixi.feature.test.tasks]
 test-install = "pip install -e ."


### PR DESCRIPTION
The FileProxyClient is used by Fileglancer for proxying data links. Previously, only the S3 client handled range reads (by simply passing the Range header to the VAST S3 backend). This range read implementation for file systems is a little more involved.

@StephanPreibisch @mkitti @neomorphic @allison-truhlar 