### PR TITLE
Fix socket hang ups

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -23,6 +23,11 @@ http {
     # Disable temp file buffering (or we run out of space when downloading huge files)
     proxy_max_temp_file_size 0;
 
+    # Timeouts
+    proxy_connect_timeout 10s;
+    proxy_read_timeout 60s;
+    proxy_send_timeout 300s;
+
     # Only return Nginx in server header
     server_tokens off;
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -9,7 +9,7 @@ events {
 }
 
 http {
-    proxy_cache_path /var/cache/nginx keys_zone=mycache:512m max_size=100g levels=1:2 inactive=1h
+    proxy_cache_path /var/cache/nginx keys_zone=mycache:512m max_size=100g levels=1:2 inactive=24h
                      loader_sleep=10ms manager_files=4000 manager_threshold=200m manager_sleep=100ms;
     map $http_cache_control $cache_bypass {
         no-cache   1;
@@ -56,6 +56,6 @@ http {
     upstream x2s3 {
         zone upstreams 64K;
         server x2s3:8000;
-        keepalive 3;
+        keepalive 16;
     }
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -15,8 +15,13 @@ http {
         no-cache   1;
     }
     proxy_cache_bypass $cache_bypass;
-    # Don’t create a temp file if body > 100 MB
-    proxy_max_temp_file_size 100m;
+
+    # Increase in-memory buffers (this assumes we have a lot of RAM)
+    proxy_buffer_size 64k;
+    proxy_buffers 32 128k;
+    proxy_busy_buffers_size 256k;
+    # Disable temp file buffering (or we run out of space when downloading huge files)
+    proxy_max_temp_file_size 0;
 
     # Only return Nginx in server header
     server_tokens off;


### PR DESCRIPTION
Tunes the nginx reverse proxy configuration to hopefully fix "socket hang up" errors observed under heavy load with large file transfers. This optimized configuration has been running running on the production servers for several months, and I haven't seen these issue reoccur yet. 

- **Disable disk buffering, increase memory buffers** — Set `proxy_max_temp_file_size 0` to prevent disk exhaustion when proxying large files, and increased in-memory buffer sizes to reduce backpressure on the upstream service
- **Add explicit proxy timeouts** — Tightened connect timeout to 10s for fast failure detection, and raised send timeout to 300s to accommodate slow clients downloading large responses
- **Extend cache lifetime and increase keepalives** — Changed cache inactive expiry from 1h to 24h to reduce redundant upstream requests, and raised keepalive connections from 3 to 16 to improve connection reuse under load


@StephanPreibisch @neomorphic 