### PR TITLE
Improve S3 API compatibility

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,6 +6,8 @@ permissions:
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ config.yaml*
 htmlconv
 assets
 
+# Java / Maven
+tests/java/target/
+
 # AI assistants
 CLAUDE.md
 .claude

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -204,6 +206,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -468,6 +472,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -683,6 +689,261 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/50/ec/72991ae51febeb11a42813fc259f0d4c8e0507f2b74b5514618d8b640365/yarl-1.20.1-cp312-cp312-macosx_11_0_arm64.whl
+  test-java:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.1.0-h15599e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1423503_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.2-h73754d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.0-h1fed272_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/maven-3.9.14-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-25.0.1-h5755bd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.46-h1321c63_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.11-h9e4cc4f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/20/26/c3c93209084e24990ad1b4214f67dce1c0183454cec9cd2cad9433f493bb/aiobotocore-2.24.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/de/5e/3bf5acea47a96a28c121b167f5ef659cf71208b19e52a88cdfa5c37f1fcc/aiohttp-3.12.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/85/13/58b70a580de00893223d61de8fea167877a3aed97d4a5e1405c9159ef925/aioitertools-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/72/66/88566a6484e746c0b075f7c9bb248e8548eda0a486de4460d150a41e2d57/boto3-1.39.11-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/2c/8a0b02d60a1dbbae7faa5af30484b016aa3023f9833dfc0d19b0b770dd6a/botocore-1.39.11-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/47/d63c60f59a59467fda0f93f46335c9d18526d7071f025cb5b89d5353ea42/fastapi-0.116.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/db/48421f62a6f77c553575201e89048e97198046b793f4a089c79a6e3268bd/frozenlist-1.7.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/af/65/753a2d8b05daf496f4a9c367fe844e90a1b2cac78e2be2c844200d10cc4c/multidict-6.6.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/37/7c/54fd5301ef38505ab235d98827207176a5c9b2aa61939b10a460ca53e123/propcache-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/4f/d073e09df851cfa251ef7840007d04db3293a0482ce607d2b993926089be/s3transfer-0.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/fd/901cfa59aaa5b30a99e16876f11abe38b59a1a2c51ffb3d7142bb6089069/starlette-0.47.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/98/28/3ab7acc5b51f4434b181b0cee8f1f4b77a65919700a355fb3617f9488874/yarl-1.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.7.1-h21dd04a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.4-h39a8b3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/maven-3.9.14-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjdk-25.0.2-h48c29e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.2-h6e31bce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.11-h9ccd52b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - pypi: https://files.pythonhosted.org/packages/20/26/c3c93209084e24990ad1b4214f67dce1c0183454cec9cd2cad9433f493bb/aiobotocore-2.24.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/83/6d/0544e6b08b748682c30b9f65640d006e51f90763b41d7c546693bc22900d/aiohttp-3.12.15-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/85/13/58b70a580de00893223d61de8fea167877a3aed97d4a5e1405c9159ef925/aioitertools-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/72/66/88566a6484e746c0b075f7c9bb248e8548eda0a486de4460d150a41e2d57/boto3-1.39.11-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/2c/8a0b02d60a1dbbae7faa5af30484b016aa3023f9833dfc0d19b0b770dd6a/botocore-1.39.11-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/47/d63c60f59a59467fda0f93f46335c9d18526d7071f025cb5b89d5353ea42/fastapi-0.116.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4c/9d/02754159955088cb52567337d1113f945b9e444c4960771ea90eb73de8db/frozenlist-1.7.0-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/99/58/45c3e75deb8855c36bd66cc1658007589662ba584dbf423d01df478dd1c5/multidict-6.6.4-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/af/6e/21293133beb550f9c901bbece755d582bfaf2176bee4774000bd4dd41884/propcache-0.3.2-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/4f/d073e09df851cfa251ef7840007d04db3293a0482ce607d2b993926089be/s3transfer-0.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/fd/901cfa59aaa5b30a99e16876f11abe38b59a1a2c51ffb3d7142bb6089069/starlette-0.47.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/67/38/688577a1cb1e656e3971fb66a3492501c5a5df56d99722e57c98249e5b8a/yarl-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maven-3.9.14-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-h258754b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.2-he92f556_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.11-hc22306f_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - pypi: https://files.pythonhosted.org/packages/20/26/c3c93209084e24990ad1b4214f67dce1c0183454cec9cd2cad9433f493bb/aiobotocore-2.24.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/1d/c8c40e611e5094330284b1aea8a4b02ca0858f8458614fa35754cab42b9c/aiohttp-3.12.15-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/85/13/58b70a580de00893223d61de8fea167877a3aed97d4a5e1405c9159ef925/aioitertools-0.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/72/66/88566a6484e746c0b075f7c9bb248e8548eda0a486de4460d150a41e2d57/boto3-1.39.11-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/2c/8a0b02d60a1dbbae7faa5af30484b016aa3023f9833dfc0d19b0b770dd6a/botocore-1.39.11-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/47/d63c60f59a59467fda0f93f46335c9d18526d7071f025cb5b89d5353ea42/fastapi-0.116.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/01/7a/0046ef1bd6699b40acd2067ed6d6670b4db2f425c56980fa21c982c2a9db/frozenlist-1.7.0-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/ca/e8c4472a93a26e4507c0b8e1f0762c0d8a32de1328ef72fd704ef9cc5447/multidict-6.6.4-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/c8/0393a0a3a2b8760eb3bde3c147f62b20044f0ddac81e9d6ed7318ec0d852/propcache-0.3.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/6d/4f/d073e09df851cfa251ef7840007d04db3293a0482ce607d2b993926089be/s3transfer-0.13.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/fd/901cfa59aaa5b30a99e16876f11abe38b59a1a2c51ffb3d7142bb6089069/starlette-0.47.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/50/ec/72991ae51febeb11a42813fc259f0d4c8e0507f2b74b5514618d8b640365/yarl-1.20.1-cp312-cp312-macosx_11_0_arm64.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -803,6 +1064,17 @@ packages:
   - frozenlist>=1.1.0
   - typing-extensions>=4.2 ; python_full_version < '3.13'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+  sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
+  md5: dcdc58c15961dbf17a0621312b01f5cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  purls: []
+  size: 584660
+  timestamp: 1768327524772
 - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
   name: annotated-types
   version: 0.7.0
@@ -943,6 +1215,32 @@ packages:
   purls: []
   size: 154402
   timestamp: 1754210968730
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
+  sha256: 3bd6a391ad60e471de76c0e9db34986c4b5058587fbf2efa5a7f54645e28c2c7
+  md5: 09262e66b19567aff4f592fb53b28760
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.44.2,<1.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.5,<2.0a0
+  - xorg-libx11 >=1.8.11,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  purls: []
+  size: 978114
+  timestamp: 1741554591855
 - pypi: https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl
   name: certifi
   version: 2025.8.3
@@ -1060,6 +1358,86 @@ packages:
   - pydantic-settings>=2.0.0 ; extra == 'all'
   - pydantic-extra-types>=2.0.0 ; extra == 'all'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 397370
+  timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  purls: []
+  size: 96530
+  timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  purls: []
+  size: 700814
+  timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  md5: 49023d73832ef61042f6a237cb2687e7
+  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+  license_family: Other
+  purls: []
+  size: 1620504
+  timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+  sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
+  md5: 8f5b0b297b59e1ac160ad4beec99dbee
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 265599
+  timestamp: 1730283881107
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 3667
+  timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+  sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+  md5: a7970cd949a077b7cb9696379d338681
+  depends:
+  - font-ttf-ubuntu
+  - font-ttf-inconsolata
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-source-code-pro
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 4059
+  timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.2-ha770c72_0.conda
+  sha256: 36857701b46828b6760c3c1652414ee504e7fc12740261ac6fcff3959b72bd7a
+  md5: eeec961fec28e747e1e1dc0446277452
+  depends:
+  - libfreetype 2.14.2 ha770c72_0
+  - libfreetype6 2.14.2 h73754d4_0
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 174292
+  timestamp: 1772757205296
 - pypi: https://files.pythonhosted.org/packages/01/7a/0046ef1bd6699b40acd2067ed6d6670b4db2f425c56980fa21c982c2a9db/frozenlist-1.7.0-cp312-cp312-macosx_11_0_arm64.whl
   name: frozenlist
   version: 1.7.0
@@ -1075,11 +1453,53 @@ packages:
   version: 1.7.0
   sha256: 488d0a7d6a0008ca0db273c542098a0fa9e7dfaa7e57f70acef43f32b3f69dca
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+  sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
+  md5: 3bf7b9fd5a7136126e0234db4b87c8b6
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 77248
+  timestamp: 1712692454246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+  sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
+  md5: 2cd94587f3a401ae05e03a6caf09539d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 99596
+  timestamp: 1755102025473
 - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
   name: h11
   version: 0.16.0
   sha256: 63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.1.0-h15599e2_0.conda
+  sha256: df2a964f5b7dd652b59da018f1d2d9ae402b815c4e5d849384344df358d2a565
+  md5: 7704b1edaa8316b8792424f254c1f586
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libglib >=2.86.0,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2058414
+  timestamp: 1759365674184
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore
   version: 1.0.9
@@ -1110,6 +1530,18 @@ packages:
   - socksio==1.* ; extra == 'socks'
   - zstandard>=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12129203
+  timestamp: 1720853576813
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
   sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
   md5: 5eb22c1d7b3fc4abb50d92d621583137
@@ -1270,6 +1702,44 @@ packages:
   - types-pywin32 ; extra == 'type'
   - shtab>=1.1.0 ; extra == 'completion'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+  sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+  md5: b38117a3c920364aff79f870c984b4a3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 134088
+  timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+  depends:
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1370023
+  timestamp: 1719463201255
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
+  sha256: 836ec4b895352110335b9fdcfa83a8dcdbe6c5fb7c06c4929130600caea91c0a
+  md5: 6f2e2c8f58160147c4d1c6f4c14cbac4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 249959
+  timestamp: 1768184673131
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1423503_1.conda
   sha256: 1a620f27d79217c1295049ba214c2f80372062fd251b569e9873d4a953d27554
   md5: 0be7c6e070c19105f966d3758448d018
@@ -1282,6 +1752,56 @@ packages:
   purls: []
   size: 676044
   timestamp: 1752032747103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+  sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
+  md5: a752488c68f2e7c456bcbd8f16eec275
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 261513
+  timestamp: 1773113328888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
+  sha256: cb83980c57e311783ee831832eb2c20ecb41e7dee6e86e8b70b8cef0e43eab55
+  md5: d4a250da4737ee127fb1fa6452a9002e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 4523621
+  timestamp: 1749905341688
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+  sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
+  md5: 6c77a605a7a689d17d4819c0f8ac9a00
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 73490
+  timestamp: 1761979956660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+  md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+  depends:
+  - ncurses
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 134676
+  timestamp: 1738479519902
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
   sha256: da2080da8f0288b95dd86765c801c6e166c4619b910b11f9a8446fb852438dc2
   md5: 4211416ecba1866fab0c6470986c22d6
@@ -1350,6 +1870,29 @@ packages:
   purls: []
   size: 39839
   timestamp: 1743434670405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.2-ha770c72_0.conda
+  sha256: 2e1bfe1e856eb707d258f669ef6851af583ceaffab5e64821b503b0f7cd09e9e
+  md5: 26c746d14402a3b6c684d045b23b9437
+  depends:
+  - libfreetype6 >=2.14.2
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 8035
+  timestamp: 1772757210108
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.2-h73754d4_0.conda
+  sha256: aba65b94bdbed52de17ec3d0c6f2ebac2ef77071ad22d6900d1614d0dd702a0c
+  md5: 8eaba3d1a4d7525c6814e861614457fd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpng >=1.6.55,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.14.2
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 386316
+  timestamp: 1772757193822
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_4.conda
   sha256: 144e35c1c2840f2dc202f6915fc41879c19eddbb8fa524e3ca4aa0d14018b26f
   md5: f406dcbb2e7bef90d793e50e79a2882b
@@ -1374,6 +1917,22 @@ packages:
   purls: []
   size: 29249
   timestamp: 1753903872571
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.0-h1fed272_0.conda
+  sha256: 33336bd55981be938f4823db74291e1323454491623de0be61ecbe6cf3a4619c
+  md5: b8e4c93f4ab70c3b6f6499299627dbdc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.46,<10.47.0a0
+  constrains:
+  - glib 2.86.0 *_0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 3978602
+  timestamp: 1757403291664
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_4.conda
   sha256: e0487a8fec78802ac04da0ac1139c3510992bc58a58cde66619dde3b363c2933
   md5: 3baf8976c96134738bba224e9ef6b1e5
@@ -1384,6 +1943,28 @@ packages:
   purls: []
   size: 447289
   timestamp: 1753903801049
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+  md5: 915f5995e94f60e9a4826e0b0920ee88
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  purls: []
+  size: 790176
+  timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+  sha256: 10056646c28115b174de81a44e23e3a0a3b95b5347d2e6c45cc6d49d35294256
+  md5: 6178c6f2fb254558238ef4e6c56fb782
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
+  size: 633831
+  timestamp: 1775962768273
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
   sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
   md5: 1a580f7796c7bf6393fddb8bbbde58dc
@@ -1429,6 +2010,17 @@ packages:
   purls: []
   size: 33731
   timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+  sha256: 36ade759122cdf0f16e2a2562a19746d96cf9c863ffaa812f2f5071ebbe9c03c
+  md5: 5f13ffc7d30ffec87864e678df9957b4
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  purls: []
+  size: 317669
+  timestamp: 1770691470744
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
   sha256: 6d9c32fc369af5a84875725f7ddfbfc2ace795c28f246dc70055a79f9b2003da
   md5: 0b367fad34931cb79e0d6b7e5c06bb1c
@@ -1461,6 +2053,45 @@ packages:
   purls: []
   size: 902645
   timestamp: 1753948599139
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_4.conda
+  sha256: b5b239e5fca53ff90669af1686c86282c970dd8204ebf477cf679872eb6d48ac
+  md5: 3c376af8888c386b9d3d1c2701e2f3ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.1.0 h767d61c_4
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 3903453
+  timestamp: 1753903894186
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_4.conda
+  sha256: 81c841c1cf4c0d06414aaa38a249f9fdd390554943065c3a0b18a9fb7e8cc495
+  md5: 2d34729cbc1da0ec988e57b13b712067
+  depends:
+  - libstdcxx 15.1.0 h8f9b012_4
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 29317
+  timestamp: 1753903924491
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+  sha256: e5f8c38625aa6d567809733ae04bb71c161a42e44a9fa8227abe61fa5c60ebe0
+  md5: cd5a90476766d53e901500df9215e927
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  purls: []
+  size: 435273
+  timestamp: 1762022005702
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
@@ -1471,6 +2102,33 @@ packages:
   purls: []
   size: 33601
   timestamp: 1680112270483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+  sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
+  md5: aea31d2e5b1091feca96fcfe945c3cf9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 429011
+  timestamp: 1752159441324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 395888
+  timestamp: 1727278577118
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
@@ -1598,6 +2256,36 @@ packages:
   version: 3.0.2
   sha256: e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/maven-3.9.14-ha770c72_0.conda
+  sha256: 97d8e14fd3b174e5afe58c7d114e9d664ace52c44a32d660ed6dc207e0961386
+  md5: 38147a5de22d8190564f1cba62c0f903
+  depends:
+  - openjdk
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8946716
+  timestamp: 1773408732770
+- conda: https://conda.anaconda.org/conda-forge/osx-64/maven-3.9.14-h694c41f_0.conda
+  sha256: 2fddd124deec740f69767562d926f35e76476f0d52e43cc9b17c7900566bab1b
+  md5: bb2d3b2b6b27ca935379a1fee5b3d722
+  depends:
+  - openjdk
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8934441
+  timestamp: 1773409235922
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/maven-3.9.14-hce30654_0.conda
+  sha256: 9fb0d4bfac11bda3043e37b1f331a99429e8c7d0ef5c773bd7fb880aedffe647
+  md5: 12a0ddbf964c36e52e76471e0132167d
+  depends:
+  - openjdk
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 8932857
+  timestamp: 1773409223258
 - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
   name: mdurl
   version: 0.1.2
@@ -1667,6 +2355,59 @@ packages:
   version: 0.3.0
   sha256: f416c35efee3e6a6c9ab7716d9e57aa0a49981be915963a82697952cba1353e1
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-25.0.1-h5755bd7_0.conda
+  sha256: 19b2268bf2d1fc4b4f48a68b9bfac620370c1b7f539671279053b0d3bcc348f1
+  md5: a40ce38da029d1d272bfd9bd7510f901
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.14,<1.3.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - giflib >=5.2.2,<5.3.0a0
+  - harfbuzz >=12.1.0
+  - lcms2 >=2.17,<3.0a0
+  - libcups >=2.3.3,<2.4.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  license: GPL-2.0-or-later WITH Classpath-exception-2.0
+  license_family: GPL
+  purls: []
+  size: 117033638
+  timestamp: 1762057253080
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openjdk-25.0.2-h48c29e7_0.conda
+  sha256: 6d75a78b11aa1100d8dda8b860ebd2943c0ba137cf87c205351ee2c02434cb23
+  md5: 7039d4add86c40fed1ff9371d405391f
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: GPL-2.0-or-later WITH Classpath-exception-2.0
+  license_family: GPL
+  purls: []
+  size: 201289992
+  timestamp: 1771443806108
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-h258754b_0.conda
+  sha256: f6f06243c1a35b6590f06be386bd5cefc5b1773b985a61b7917b93dab4cf18ec
+  md5: a4024e03865a7411c1028eac83d1956c
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: GPL-2.0-or-later WITH Classpath-exception-2.0
+  license_family: GPL
+  purls: []
+  size: 199165105
+  timestamp: 1771443790144
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
   sha256: c9f54d4e8212f313be7b02eb962d0cb13a8dae015683a403d3accd4add3e520e
   md5: ffffb341206dd0dab0c36053c048d621
@@ -1706,6 +2447,19 @@ packages:
   version: '25.0'
   sha256: 29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.46-h1321c63_0.conda
+  sha256: 5c7380c8fd3ad5fc0f8039069a45586aa452cf165264bc5a437ad80397b32934
+  md5: 7fa07cb0fb1b625a089ccc01218ee5b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1209177
+  timestamp: 1756742976157
 - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
   sha256: ec9ed3cef137679f3e3a68e286c6efd52144684e1be0b05004d9699882dadcdd
   md5: dfce4b2af4bfe90cdcaf56ca0b28ddf5
@@ -1719,6 +2473,19 @@ packages:
   - pkg:pypi/pip?source=hash-mapping
   size: 1177168
   timestamp: 1753924973872
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+  sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
+  md5: c01af13bdc553d1a8fbfff6e8db075f0
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 450960
+  timestamp: 1754665235234
 - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
   name: pluggy
   version: 1.6.0
@@ -1745,6 +2512,17 @@ packages:
   version: 0.3.2
   sha256: 28710b0d3975117239c76600ea351934ac7b5ff56e60953474342608dbbb6154
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 8252
+  timestamp: 1726802366959
 - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
   name: pycparser
   version: '2.22'
@@ -2282,6 +3060,156 @@ packages:
   version: 1.17.3
   sha256: 042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+  sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+  md5: fb901ff28063514abb6046c9ec2c4a45
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 58628
+  timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+  sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+  md5: 1c74ff8c35dcadf952a16f752ca5aa49
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 27590
+  timestamp: 1741896361728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+  sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
+  md5: 861fb6ccbc677bb9a9fb2468430b9c6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 839652
+  timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+  sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
+  md5: b2895afaf55bf96a8c8282a2e47a5de0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 15321
+  timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+  sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
+  md5: 1dafce8548e38671bea82e3f5c6ce22f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20591
+  timestamp: 1762976546182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+  sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
+  md5: 34e54f03dfea3e7a2dcf1453a85f1085
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 50326
+  timestamp: 1769445253162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+  sha256: 83c4c99d60b8784a611351220452a0a85b080668188dce5dfa394b723d7b64f4
+  md5: ba231da7fccf9ea1e768caf5c7099b84
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20071
+  timestamp: 1759282564045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
+  md5: 17dcc85db3c7886650b8908b183d6876
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 47179
+  timestamp: 1727799254088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+  sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
+  md5: e192019153591938acf7322b6459d36e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 30456
+  timestamp: 1769445263457
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+  sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
+  md5: 96d57aba173e878a2089d5638016dc5e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 33005
+  timestamp: 1734229037766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+  sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
+  md5: 279b0de5f6ba95457190a1c459a64e31
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 379686
+  timestamp: 1731860547604
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.7.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 32808
+  timestamp: 1727964811275
 - pypi: https://files.pythonhosted.org/packages/50/ec/72991ae51febeb11a42813fc259f0d4c8e0507f2b74b5514618d8b640365/yarl-1.20.1-cp312-cp312-macosx_11_0_arm64.whl
   name: yarl
   version: 1.20.1
@@ -2309,3 +3237,14 @@ packages:
   - multidict>=4.0
   - propcache>=0.2.1
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 601375
+  timestamp: 1764777111296

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,13 @@ dev-launch-remote = "uvicorn x2s3.app:app --host 0.0.0.0 --port 8000 --reload --
 test-install = "pip install -e ."
 test = { cmd = "python -m pytest --cov=x2s3 --cov-report html -W ignore::DeprecationWarning", depends-on = ["test-install"] }
 
+[tool.pixi.feature.test-java.dependencies]
+openjdk = ">=17"
+maven = ">=3.9"
+
+[tool.pixi.feature.test-java.tasks]
+test-java = "mvn test -f tests/java/pom.xml"
+
 [tool.pixi.feature.release.tasks]
 pypi-build = "python -m build"
 pypi-upload = "twine upload dist/*"
@@ -71,6 +78,7 @@ pypi-upload = "twine upload dist/*"
 [tool.pixi.environments]
 default = {features = [], solve-group = "default"}
 test = {features = ["test"], solve-group = "default"}
+test-java = {features = ["test-java"], solve-group = "default"}
 release = {features = ["release"], solve-group = "default"}
 
 [tool.pixi.dependencies]

--- a/scripts/compare_s3.py
+++ b/scripts/compare_s3.py
@@ -1,0 +1,1150 @@
+#!/usr/bin/env python3
+"""
+Compare real AWS S3 bucket behavior with x2s3 proxy behavior.
+
+AWS:   https://s3.us-east-1.amazonaws.com/janelia-data-examples
+Proxy: https://nextflow.int.janelia.org:8003/janelia-data-examples
+"""
+
+import requests
+import xml.etree.ElementTree as ET
+import json
+import sys
+import hashlib
+import traceback
+from collections import OrderedDict
+
+AWS_BASE = "https://s3.us-east-1.amazonaws.com"
+AWS_BUCKET = f"{AWS_BASE}/janelia-data-examples"
+PROXY_BASE = "https://nextflow.int.janelia.org:8003"
+PROXY_BUCKET = f"{PROXY_BASE}/janelia-data-examples"
+
+TIMEOUT = 30
+
+# Known files in the bucket
+SMALL_JSON_KEY = "jrc_mus_lung_covid.n5/attributes.json"
+SMALL_BINARY_KEY = "jrc_mus_lung_covid.n5/render/v1_acquire_align___20210609_224836/s0/0/0/5"
+DIR_PREFIX = "jrc_mus_lung_covid.n5/"
+NESTED_PREFIX = "jrc_mus_lung_covid.n5/render/"
+
+results = []
+
+
+def log(msg):
+    print(msg)
+
+
+def normalize_xml(xml_str):
+    """Parse XML, stripping namespace prefixes."""
+    try:
+        root = ET.fromstring(xml_str)
+        for elem in root.iter():
+            if '}' in elem.tag:
+                elem.tag = elem.tag.split('}', 1)[1]
+        return root
+    except ET.ParseError:
+        return None
+
+
+def compare_xml_elements(aws_root, proxy_root, path=""):
+    """Deep compare two XML trees; return list of unique difference descriptions."""
+    diffs = set()
+    _compare_recursive(aws_root, proxy_root, path, diffs)
+    return sorted(diffs)
+
+
+def _compare_recursive(aws_elem, proxy_elem, path, diffs):
+    aws_tag = aws_elem.tag.split('}')[-1] if '}' in aws_elem.tag else aws_elem.tag
+    proxy_tag = proxy_elem.tag.split('}')[-1] if '}' in proxy_elem.tag else proxy_elem.tag
+
+    if aws_tag != proxy_tag:
+        diffs.add(f"Tag mismatch at {path}: AWS=<{aws_tag}> vs Proxy=<{proxy_tag}>")
+        return
+
+    current_path = f"{path}/{aws_tag}"
+
+    # Compare text
+    aws_text = (aws_elem.text or '').strip()
+    proxy_text = (proxy_elem.text or '').strip()
+    if aws_text != proxy_text:
+        # Deduplicate by pattern rather than per-item
+        if 'LastModified' in current_path:
+            diffs.add(f"LastModified format differs: AWS uses '.000Z' suffix vs Proxy uses '+00:00' "
+                      f"(e.g. AWS='{aws_text}' vs Proxy='{proxy_text}')")
+        elif 'ContinuationToken' in current_path or 'NextContinuationToken' in current_path:
+            diffs.add(f"ContinuationToken values differ (expected - opaque tokens are server-specific)")
+        else:
+            diffs.add(f"Text at {current_path}: AWS='{aws_text[:80]}' vs Proxy='{proxy_text[:80]}'")
+
+    # Compare children
+    aws_children = list(aws_elem)
+    proxy_children = list(proxy_elem)
+
+    aws_child_tags = [c.tag.split('}')[-1] if '}' in c.tag else c.tag for c in aws_children]
+    proxy_child_tags = [c.tag.split('}')[-1] if '}' in c.tag else c.tag for c in proxy_children]
+
+    aws_tag_set = set(aws_child_tags)
+    proxy_tag_set = set(proxy_child_tags)
+
+    for tag in aws_tag_set - proxy_tag_set:
+        diffs.add(f"Element <{tag}> present in AWS but MISSING in Proxy at {current_path}")
+    for tag in proxy_tag_set - aws_tag_set:
+        diffs.add(f"Element <{tag}> present in Proxy but MISSING in AWS at {current_path}")
+
+    # Group children by tag
+    aws_by_tag = {}
+    for c in aws_children:
+        t = c.tag.split('}')[-1] if '}' in c.tag else c.tag
+        aws_by_tag.setdefault(t, []).append(c)
+
+    proxy_by_tag = {}
+    for c in proxy_children:
+        t = c.tag.split('}')[-1] if '}' in c.tag else c.tag
+        proxy_by_tag.setdefault(t, []).append(c)
+
+    for tag in aws_tag_set & proxy_tag_set:
+        aws_list = aws_by_tag[tag]
+        proxy_list = proxy_by_tag[tag]
+        if len(aws_list) != len(proxy_list):
+            diffs.add(f"Count of <{tag}> at {current_path}: AWS={len(aws_list)} vs Proxy={len(proxy_list)}")
+        for i in range(min(len(aws_list), len(proxy_list))):
+            _compare_recursive(aws_list[i], proxy_list[i], current_path, diffs)
+
+
+def record_test(name, category, aws_status, proxy_status, diffs, notes="",
+                aws_headers=None, proxy_headers=None):
+    results.append({
+        'name': name,
+        'category': category,
+        'aws_status': aws_status,
+        'proxy_status': proxy_status,
+        'status_match': aws_status == proxy_status,
+        'diffs': diffs,
+        'notes': notes,
+        'aws_headers': aws_headers or {},
+        'proxy_headers': proxy_headers or {},
+    })
+
+
+def do_request(method, url, headers=None, params=None, retries=2):
+    for attempt in range(retries + 1):
+        try:
+            resp = requests.request(method, url, headers=headers, params=params,
+                                    timeout=TIMEOUT, allow_redirects=False)
+            return resp
+        except Exception as e:
+            log(f"  REQUEST EXCEPTION (attempt {attempt+1}): {type(e).__name__}: {e}")
+            if attempt < retries:
+                import time
+                time.sleep(1)
+    return None
+
+
+def compare_headers(aws_resp, proxy_resp, keys):
+    diffs = []
+    aws_h, proxy_h = {}, {}
+    for key in keys:
+        aws_val = aws_resp.headers.get(key)
+        proxy_val = proxy_resp.headers.get(key)
+        if aws_val:
+            aws_h[key] = aws_val
+        if proxy_val:
+            proxy_h[key] = proxy_val
+        if aws_val != proxy_val:
+            diffs.append(f"Header '{key}': AWS='{aws_val}' vs Proxy='{proxy_val}'")
+    return aws_h, proxy_h, diffs
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+def test_list_v2_basic():
+    name = "ListObjectsV2 - basic defaults"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "max-keys": "5"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", getattr(aws, 'status_code', None),
+                          getattr(proxy, 'status_code', None),
+                          ["One or both requests failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    aws_h, proxy_h, hd = compare_headers(aws, proxy, ['Content-Type', 'Server'])
+    diffs.extend(hd)
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs,
+                aws_headers=aws_h, proxy_headers=proxy_h)
+
+
+def test_list_v2_delimiter():
+    name = "ListObjectsV2 - with delimiter=/"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "delimiter": "/"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs)
+
+
+def test_list_v2_prefix_delimiter():
+    name = "ListObjectsV2 - prefix + delimiter"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "prefix": DIR_PREFIX, "delimiter": "/", "max-keys": "10"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs)
+
+
+def test_list_v2_max_keys():
+    name = "ListObjectsV2 - max-keys=2 with delimiter"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "max-keys": "2", "delimiter": "/"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs)
+
+
+def test_list_v2_start_after():
+    name = "ListObjectsV2 - start-after"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "start-after": "fly-efish/", "delimiter": "/", "max-keys": "5"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs)
+
+
+def test_list_v2_encoding_type():
+    name = "ListObjectsV2 - encoding-type=url"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "encoding-type": "url", "delimiter": "/", "max-keys": "5"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs)
+
+
+def test_list_v2_pagination():
+    name = "ListObjectsV2 - pagination"
+    log(f"\n--- {name} ---")
+
+    # Page 1
+    params = {"list-type": "2", "max-keys": "1", "delimiter": "/"}
+    aws1 = do_request("GET", AWS_BUCKET, params=params)
+    proxy1 = do_request("GET", PROXY_BUCKET, params=params)
+    if not aws1 or not proxy1:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+
+    # Extract tokens
+    aws_root1 = normalize_xml(aws1.text)
+    proxy_root1 = normalize_xml(proxy1.text)
+
+    aws_token = proxy_token = None
+    if aws_root1 is not None:
+        nct = aws_root1.find('NextContinuationToken')
+        aws_token = nct.text if nct is not None else None
+    if proxy_root1 is not None:
+        nct = proxy_root1.find('NextContinuationToken')
+        proxy_token = nct.text if nct is not None else None
+
+    notes = f"Page 1 - AWS IsTruncated/token present: {aws_token is not None}, Proxy: {proxy_token is not None}"
+
+    # Compare page 1 structure (ignoring token values)
+    if aws_root1 is not None and proxy_root1 is not None:
+        diffs.extend(compare_xml_elements(aws_root1, proxy_root1))
+
+    # Page 2 - use each system's own token
+    if aws_token and proxy_token:
+        params2a = {"list-type": "2", "max-keys": "1", "delimiter": "/",
+                    "continuation-token": aws_token}
+        params2p = {"list-type": "2", "max-keys": "1", "delimiter": "/",
+                    "continuation-token": proxy_token}
+        aws2 = do_request("GET", AWS_BUCKET, params=params2a)
+        proxy2 = do_request("GET", PROXY_BUCKET, params=params2p)
+
+        if aws2 and proxy2:
+            aws_root2 = normalize_xml(aws2.text)
+            proxy_root2 = normalize_xml(proxy2.text)
+            if aws_root2 is not None and proxy_root2 is not None:
+                page2_diffs = compare_xml_elements(aws_root2, proxy_root2)
+                for d in page2_diffs:
+                    diffs.append(f"[Page2] {d}")
+            notes += f"\nPage 2 status: AWS={aws2.status_code} Proxy={proxy2.status_code}"
+
+    record_test(name, "ListObjectsV2", aws1.status_code, proxy1.status_code, diffs, notes)
+
+
+def test_list_v2_nonexistent_prefix():
+    name = "ListObjectsV2 - nonexistent prefix"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "prefix": "this-does-not-exist-xyz/"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs)
+
+
+def test_list_v2_no_list_type():
+    """GET bucket without list-type param. AWS returns ListObjects v1, x2s3 returns v2."""
+    name = "ListObjectsV2 - no list-type (v1 vs v2 behavior)"
+    log(f"\n--- {name} ---")
+
+    aws = do_request("GET", AWS_BUCKET, headers={"Accept": "application/xml"})
+    proxy = do_request("GET", PROXY_BUCKET, headers={"Accept": "application/xml"})
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+
+    aws_tag = aws_root.tag if aws_root is not None else None
+    proxy_tag = proxy_root.tag if proxy_root is not None else None
+
+    notes = f"AWS root: <{aws_tag}>, Proxy root: <{proxy_tag}>"
+
+    # Check structural differences between v1 and v2
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs, notes)
+
+
+def test_list_v2_trailing_slash():
+    name = "ListObjectsV2 - trailing slash on bucket path"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "delimiter": "/", "max-keys": "5"}
+    aws = do_request("GET", AWS_BUCKET + "/", params=params)
+    proxy = do_request("GET", PROXY_BUCKET + "/", params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs)
+
+
+def test_list_v2_max_keys_zero():
+    name = "ListObjectsV2 - max-keys=0 (edge case)"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "max-keys": "0"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+
+    aws_status = aws.status_code if aws is not None else None
+    proxy_status = proxy.status_code if proxy is not None else None
+
+    diffs = []
+    if aws_status != proxy_status:
+        diffs.append(f"Status: AWS={aws_status} vs Proxy={proxy_status}")
+
+    notes = ""
+    if aws is not None:
+        notes += f"AWS: {aws.status_code} {aws.text[:300]}\n"
+    if proxy is not None:
+        notes += f"Proxy: {proxy.status_code} {proxy.text[:300]}"
+
+    record_test(name, "ListObjectsV2", aws_status, proxy_status, diffs, notes)
+
+
+def test_list_v2_max_keys_above_limit():
+    name = "ListObjectsV2 - max-keys=1001 (above S3 limit)"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "max-keys": "1001"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+
+    aws_status = aws.status_code if aws is not None else None
+    proxy_status = proxy.status_code if proxy is not None else None
+
+    diffs = []
+    if aws_status != proxy_status:
+        diffs.append(f"Status: AWS={aws_status} vs Proxy={proxy_status}")
+
+    notes = ""
+    if aws is not None:
+        notes += f"AWS: {aws.status_code} {aws.text[:300]}\n"
+    if proxy is not None:
+        notes += f"Proxy: {proxy.status_code} {proxy.text[:300]}"
+
+    record_test(name, "ListObjectsV2", aws_status, proxy_status, diffs, notes)
+
+
+def test_list_v1():
+    name = "ListObjects - v1 (list-type=1)"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "1"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+
+    aws_status = aws.status_code if aws is not None else None
+    proxy_status = proxy.status_code if proxy is not None else None
+
+    diffs = []
+    if aws_status != proxy_status:
+        diffs.append(f"Status: AWS={aws_status} vs Proxy={proxy_status}")
+
+    notes = ""
+    if aws:
+        notes += f"AWS: {aws.status_code} {aws.text[:400]}\n"
+    if proxy:
+        notes += f"Proxy: {proxy.status_code} {proxy.text[:400]}"
+
+    record_test(name, "ListObjects", aws_status, proxy_status, diffs, notes)
+
+
+def test_list_v2_fetch_owner():
+    name = "ListObjectsV2 - fetch-owner=true"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "fetch-owner": "true", "max-keys": "3", "prefix": DIR_PREFIX}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs)
+
+
+def test_list_v2_no_delimiter_flat():
+    name = "ListObjectsV2 - no delimiter (flat listing)"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "prefix": DIR_PREFIX, "max-keys": "5"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ListObjectsV2", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "ListObjectsV2", aws.status_code, proxy.status_code, diffs)
+
+
+def test_invalid_continuation_token():
+    name = "ListObjectsV2 - invalid continuation token"
+    log(f"\n--- {name} ---")
+    params = {"list-type": "2", "continuation-token": "BOGUS_TOKEN_XYZ"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+
+    aws_status = aws.status_code if aws is not None else None
+    proxy_status = proxy.status_code if proxy is not None else None
+
+    diffs = []
+    if aws_status != proxy_status:
+        diffs.append(f"Status: AWS={aws_status} vs Proxy={proxy_status}")
+
+    notes = ""
+    if aws:
+        notes += f"AWS: {aws.status_code} {aws.text[:400]}\n"
+    if proxy:
+        notes += f"Proxy: {proxy.status_code} {proxy.text[:400]}"
+
+    record_test(name, "ListObjectsV2", aws_status, proxy_status, diffs, notes)
+
+
+def test_get_object_small_json():
+    name = "GetObject - small JSON file"
+    log(f"\n--- {name} ---")
+
+    aws = do_request("GET", f"{AWS_BUCKET}/{SMALL_JSON_KEY}")
+    proxy = do_request("GET", f"{PROXY_BUCKET}/{SMALL_JSON_KEY}")
+    if aws is None or proxy is None:
+        return record_test(name, "GetObject", None, None,
+                          [f"Request failed - AWS={aws is not None}, Proxy={proxy is not None}"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    if aws.content != proxy.content:
+        diffs.append(f"Body differs: AWS={aws.text[:200]!r} vs Proxy={proxy.text[:200]!r}")
+
+    header_keys = ['Content-Type', 'Content-Length', 'ETag', 'Accept-Ranges',
+                   'Last-Modified', 'Content-Disposition']
+    aws_h, proxy_h, hd = compare_headers(aws, proxy, header_keys)
+    diffs.extend(hd)
+
+    record_test(name, "GetObject", aws.status_code, proxy.status_code, diffs,
+                f"Key: {SMALL_JSON_KEY}", aws_h, proxy_h)
+
+
+def test_get_object_binary():
+    name = "GetObject - binary file (content hash)"
+    log(f"\n--- {name} ---")
+
+    aws = do_request("GET", f"{AWS_BUCKET}/{SMALL_BINARY_KEY}")
+    proxy = do_request("GET", f"{PROXY_BUCKET}/{SMALL_BINARY_KEY}")
+    if aws is None or proxy is None:
+        return record_test(name, "GetObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    aws_md5 = hashlib.md5(aws.content).hexdigest()
+    proxy_md5 = hashlib.md5(proxy.content).hexdigest()
+    if aws_md5 != proxy_md5:
+        diffs.append(f"Content MD5: AWS={aws_md5} vs Proxy={proxy_md5}")
+        diffs.append(f"Content length: AWS={len(aws.content)} vs Proxy={len(proxy.content)}")
+
+    header_keys = ['Content-Type', 'Content-Length', 'ETag', 'Accept-Ranges',
+                   'Content-Disposition']
+    aws_h, proxy_h, hd = compare_headers(aws, proxy, header_keys)
+    diffs.extend(hd)
+
+    notes = f"Key: {SMALL_BINARY_KEY}, size={len(aws.content)}, md5 match={aws_md5==proxy_md5}"
+
+    record_test(name, "GetObject", aws.status_code, proxy.status_code, diffs,
+                notes, aws_h, proxy_h)
+
+
+def test_get_object_nonexistent():
+    name = "GetObject - nonexistent key"
+    log(f"\n--- {name} ---")
+
+    key = "this-key-xyz-definitely-does-not-exist.txt"
+    aws = do_request("GET", f"{AWS_BUCKET}/{key}")
+    proxy = do_request("GET", f"{PROXY_BUCKET}/{key}")
+    if aws is None or proxy is None:
+        return record_test(name, "GetObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+    elif aws.text != proxy.text:
+        diffs.append(f"Response body differs")
+
+    notes = f"AWS body: {aws.text[:400]}\nProxy body: {proxy.text[:400]}"
+
+    record_test(name, "GetObject", aws.status_code, proxy.status_code, diffs, notes)
+
+
+def test_get_object_range():
+    name = "GetObject - Range bytes=0-9"
+    log(f"\n--- {name} ---")
+
+    headers = {"Range": "bytes=0-9"}
+    aws = do_request("GET", f"{AWS_BUCKET}/{SMALL_JSON_KEY}", headers=headers)
+    proxy = do_request("GET", f"{PROXY_BUCKET}/{SMALL_JSON_KEY}", headers=headers)
+    if aws is None or proxy is None:
+        return record_test(name, "GetObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    if aws.content != proxy.content:
+        diffs.append(f"Body: AWS={aws.content!r} vs Proxy={proxy.content!r}")
+
+    header_keys = ['Content-Type', 'Content-Length', 'Content-Range', 'Accept-Ranges', 'ETag']
+    aws_h, proxy_h, hd = compare_headers(aws, proxy, header_keys)
+    diffs.extend(hd)
+
+    record_test(name, "GetObject", aws.status_code, proxy.status_code, diffs,
+                "Range: bytes=0-9", aws_h, proxy_h)
+
+
+def test_get_object_range_suffix():
+    name = "GetObject - Range bytes=-5 (last 5)"
+    log(f"\n--- {name} ---")
+
+    headers = {"Range": "bytes=-5"}
+    aws = do_request("GET", f"{AWS_BUCKET}/{SMALL_JSON_KEY}", headers=headers)
+    proxy = do_request("GET", f"{PROXY_BUCKET}/{SMALL_JSON_KEY}", headers=headers)
+    if aws is None or proxy is None:
+        return record_test(name, "GetObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    if aws.content != proxy.content:
+        diffs.append(f"Body: AWS={aws.content!r} vs Proxy={proxy.content!r}")
+
+    header_keys = ['Content-Range', 'Content-Length']
+    aws_h, proxy_h, hd = compare_headers(aws, proxy, header_keys)
+    diffs.extend(hd)
+
+    record_test(name, "GetObject", aws.status_code, proxy.status_code, diffs,
+                "", aws_h, proxy_h)
+
+
+def test_get_object_range_open():
+    name = "GetObject - Range bytes=5- (from 5 to end)"
+    log(f"\n--- {name} ---")
+
+    headers = {"Range": "bytes=5-"}
+    aws = do_request("GET", f"{AWS_BUCKET}/{SMALL_JSON_KEY}", headers=headers)
+    proxy = do_request("GET", f"{PROXY_BUCKET}/{SMALL_JSON_KEY}", headers=headers)
+    if aws is None or proxy is None:
+        return record_test(name, "GetObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    if aws.content != proxy.content:
+        diffs.append(f"Body length: AWS={len(aws.content)} vs Proxy={len(proxy.content)}")
+
+    header_keys = ['Content-Range', 'Content-Length']
+    aws_h, proxy_h, hd = compare_headers(aws, proxy, header_keys)
+    diffs.extend(hd)
+
+    record_test(name, "GetObject", aws.status_code, proxy.status_code, diffs,
+                "", aws_h, proxy_h)
+
+
+def test_get_object_range_invalid():
+    name = "GetObject - Range bytes=99999-100000 (unsatisfiable)"
+    log(f"\n--- {name} ---")
+
+    headers = {"Range": "bytes=99999-100000"}
+    aws = do_request("GET", f"{AWS_BUCKET}/{SMALL_JSON_KEY}", headers=headers)
+    proxy = do_request("GET", f"{PROXY_BUCKET}/{SMALL_JSON_KEY}", headers=headers)
+    if aws is None or proxy is None:
+        return record_test(name, "GetObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    notes = f"AWS: {aws.status_code} {aws.text[:300]}\nProxy: {proxy.status_code} {proxy.text[:300]}"
+
+    record_test(name, "GetObject", aws.status_code, proxy.status_code, diffs, notes)
+
+
+def test_get_directory_no_slash():
+    name = "GetObject - directory path (no trailing slash)"
+    log(f"\n--- {name} ---")
+
+    path = "jrc_mus_lung_covid.n5"
+    aws = do_request("GET", f"{AWS_BUCKET}/{path}", headers={"Accept": "application/xml"})
+    proxy = do_request("GET", f"{PROXY_BUCKET}/{path}", headers={"Accept": "application/xml"})
+    if aws is None or proxy is None:
+        return record_test(name, "GetObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    notes = f"AWS: {aws.status_code} body[:300]={aws.text[:300]}\nProxy: {proxy.status_code} body[:300]={proxy.text[:300]}"
+
+    record_test(name, "GetObject", aws.status_code, proxy.status_code, diffs, notes)
+
+
+def test_get_directory_with_slash():
+    name = "GetObject - directory path (with trailing slash)"
+    log(f"\n--- {name} ---")
+
+    path = "jrc_mus_lung_covid.n5/"
+    aws = do_request("GET", f"{AWS_BUCKET}/{path}",
+                     headers={"Accept": "application/xml"},
+                     params={"list-type": "2", "max-keys": "3", "delimiter": "/"})
+    proxy = do_request("GET", f"{PROXY_BUCKET}/{path}",
+                       headers={"Accept": "application/xml"},
+                       params={"list-type": "2", "max-keys": "3", "delimiter": "/"})
+    if aws is None or proxy is None:
+        return record_test(name, "GetObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    notes = f"AWS: {aws.status_code}, Proxy: {proxy.status_code}"
+
+    record_test(name, "GetObject", aws.status_code, proxy.status_code, diffs, notes)
+
+
+def test_head_object():
+    name = "HeadObject - existing key"
+    log(f"\n--- {name} ---")
+
+    aws = do_request("HEAD", f"{AWS_BUCKET}/{SMALL_JSON_KEY}")
+    proxy = do_request("HEAD", f"{PROXY_BUCKET}/{SMALL_JSON_KEY}")
+    if aws is None or proxy is None:
+        return record_test(name, "HeadObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: {aws.status_code} vs {proxy.status_code}")
+
+    header_keys = ['Content-Type', 'Content-Length', 'ETag', 'Accept-Ranges',
+                   'Last-Modified', 'Cache-Control', 'x-amz-server-side-encryption',
+                   'x-amz-storage-class']
+    aws_h, proxy_h, hd = compare_headers(aws, proxy, header_keys)
+    diffs.extend(hd)
+
+    record_test(name, "HeadObject", aws.status_code, proxy.status_code, diffs,
+                f"Key: {SMALL_JSON_KEY}", aws_h, proxy_h)
+
+
+def test_head_object_nonexistent():
+    name = "HeadObject - nonexistent key"
+    log(f"\n--- {name} ---")
+
+    key = "this-key-xyz-does-not-exist.txt"
+    aws = do_request("HEAD", f"{AWS_BUCKET}/{key}")
+    proxy = do_request("HEAD", f"{PROXY_BUCKET}/{key}")
+    if aws is None or proxy is None:
+        return record_test(name, "HeadObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    # For HEAD, check error-related headers
+    header_keys = ['Content-Type', 'x-amz-error-code', 'x-amz-error-message']
+    aws_h, proxy_h, hd = compare_headers(aws, proxy, header_keys)
+    diffs.extend(hd)
+
+    record_test(name, "HeadObject", aws.status_code, proxy.status_code, diffs,
+                "", aws_h, proxy_h)
+
+
+def test_head_object_directory():
+    name = "HeadObject - directory prefix"
+    log(f"\n--- {name} ---")
+
+    aws = do_request("HEAD", f"{AWS_BUCKET}/{DIR_PREFIX}")
+    proxy = do_request("HEAD", f"{PROXY_BUCKET}/{DIR_PREFIX}")
+    if aws is None or proxy is None:
+        return record_test(name, "HeadObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    record_test(name, "HeadObject", aws.status_code, proxy.status_code, diffs)
+
+
+def test_head_bucket():
+    name = "HeadBucket"
+    log(f"\n--- {name} ---")
+
+    aws = do_request("HEAD", AWS_BUCKET)
+    proxy = do_request("HEAD", PROXY_BUCKET)
+    if aws is None or proxy is None:
+        return record_test(name, "HeadBucket", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    header_keys = ['Content-Type', 'x-amz-bucket-region', 'x-amz-request-id']
+    aws_h, proxy_h, hd = compare_headers(aws, proxy, header_keys)
+    diffs.extend(hd)
+
+    record_test(name, "HeadBucket", aws.status_code, proxy.status_code, diffs,
+                "", aws_h, proxy_h)
+
+
+def test_get_bucket_acl():
+    name = "GetBucketAcl"
+    log(f"\n--- {name} ---")
+
+    params = {"acl": ""}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "ACL", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    notes = f"AWS: {aws.status_code} body={aws.text[:400]}\nProxy: {proxy.status_code} body={proxy.text[:400]}"
+
+    record_test(name, "ACL", aws.status_code, proxy.status_code, diffs, notes)
+
+
+def test_nonexistent_bucket():
+    name = "Nonexistent bucket"
+    log(f"\n--- {name} ---")
+
+    aws = do_request("GET", f"{AWS_BASE}/this-bucket-xyz-does-not-exist-99",
+                     params={"list-type": "2"})
+    proxy = do_request("GET", f"{PROXY_BASE}/this-bucket-xyz-does-not-exist-99",
+                       params={"list-type": "2"})
+    if aws is None or proxy is None:
+        return record_test(name, "Error", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    notes = f"AWS: {aws.status_code} {aws.text[:400]}\nProxy: {proxy.status_code} {proxy.text[:400]}"
+
+    record_test(name, "Error", aws.status_code, proxy.status_code, diffs, notes)
+
+
+def test_list_buckets():
+    name = "ListBuckets (GET /)"
+    log(f"\n--- {name} ---")
+
+    aws = do_request("GET", AWS_BASE, headers={"Accept": "application/xml"})
+    proxy = do_request("GET", PROXY_BASE, headers={"Accept": "application/xml"})
+    if aws is None or proxy is None:
+        return record_test(name, "ListBuckets", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    notes = f"AWS: {aws.status_code} body[:300]={aws.text[:300]}\nProxy: {proxy.status_code} body[:300]={proxy.text[:300]}"
+
+    record_test(name, "ListBuckets", aws.status_code, proxy.status_code, diffs, notes)
+
+
+def test_xml_namespace():
+    name = "XML namespace and declaration"
+    log(f"\n--- {name} ---")
+
+    params = {"list-type": "2", "max-keys": "1"}
+    aws = do_request("GET", AWS_BUCKET, params=params)
+    proxy = do_request("GET", PROXY_BUCKET, params=params)
+    if aws is None or proxy is None:
+        return record_test(name, "XML", None, None, ["Request failed"])
+
+    diffs = []
+
+    # xmlns
+    if ('xmlns' in aws.text[:500]) != ('xmlns' in proxy.text[:500]):
+        aws_has = 'xmlns' in aws.text[:500]
+        proxy_has = 'xmlns' in proxy.text[:500]
+        diffs.append(f"xmlns namespace: AWS={aws_has}, Proxy={proxy_has}")
+
+    # XML declaration encoding
+    if 'encoding="UTF-8"' in aws.text[:100] and "encoding='utf-8'" in proxy.text[:100]:
+        diffs.append("XML declaration encoding quotes: AWS uses double quotes, Proxy uses single quotes")
+
+    # Element ordering
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        aws_order = [c.tag for c in aws_root]
+        proxy_order = [c.tag for c in proxy_root]
+        if aws_order != proxy_order:
+            diffs.append(f"Child element order differs:\n    AWS:   {aws_order}\n    Proxy: {proxy_order}")
+
+    notes = f"AWS first line: {aws.text[:150]}\nProxy first line: {proxy.text[:150]}"
+
+    record_test(name, "XML", aws.status_code, proxy.status_code, diffs, notes)
+
+
+def test_content_type_json():
+    name = "Content-Type for JSON file"
+    log(f"\n--- {name} ---")
+
+    aws = do_request("HEAD", f"{AWS_BUCKET}/{SMALL_JSON_KEY}")
+    proxy = do_request("HEAD", f"{PROXY_BUCKET}/{SMALL_JSON_KEY}")
+    if aws is None or proxy is None:
+        return record_test(name, "ContentType", None, None, ["Request failed"])
+
+    diffs = []
+    aws_ct = aws.headers.get('Content-Type', '')
+    proxy_ct = proxy.headers.get('Content-Type', '')
+    if aws_ct != proxy_ct:
+        diffs.append(f"Content-Type: AWS='{aws_ct}' vs Proxy='{proxy_ct}'")
+
+    record_test(name, "ContentType", aws.status_code, proxy.status_code, diffs,
+                "", {'Content-Type': aws_ct}, {'Content-Type': proxy_ct})
+
+
+def test_content_type_binary():
+    name = "Content-Type for extensionless binary file"
+    log(f"\n--- {name} ---")
+
+    key = "jrc_mus_lung_covid.n5/render/v1_acquire_align___20210609_224836/s0/0/0/0"
+    aws = do_request("HEAD", f"{AWS_BUCKET}/{key}")
+    proxy = do_request("HEAD", f"{PROXY_BUCKET}/{key}")
+    if aws is None or proxy is None:
+        return record_test(name, "ContentType", None, None, ["Request failed"])
+
+    diffs = []
+    aws_ct = aws.headers.get('Content-Type', '')
+    proxy_ct = proxy.headers.get('Content-Type', '')
+    if aws_ct != proxy_ct:
+        diffs.append(f"Content-Type: AWS='{aws_ct}' vs Proxy='{proxy_ct}'")
+
+    record_test(name, "ContentType", aws.status_code, proxy.status_code, diffs,
+                f"Key: {key}", {'Content-Type': aws_ct}, {'Content-Type': proxy_ct})
+
+
+def test_get_object_special_chars():
+    name = "GetObject - URL-encoded key (404 handling)"
+    log(f"\n--- {name} ---")
+
+    key = "test%20file%20with%20spaces.txt"
+    aws = do_request("GET", f"{AWS_BUCKET}/{key}")
+    proxy = do_request("GET", f"{PROXY_BUCKET}/{key}")
+    if aws is None or proxy is None:
+        return record_test(name, "GetObject", None, None, ["Request failed"])
+
+    diffs = []
+    if aws.status_code != proxy.status_code:
+        diffs.append(f"Status: AWS={aws.status_code} vs Proxy={proxy.status_code}")
+
+    aws_root = normalize_xml(aws.text)
+    proxy_root = normalize_xml(proxy.text)
+    if aws_root is not None and proxy_root is not None:
+        diffs.extend(compare_xml_elements(aws_root, proxy_root))
+
+    record_test(name, "GetObject", aws.status_code, proxy.status_code, diffs)
+
+
+# ===========================================================================
+# Report
+# ===========================================================================
+
+def generate_report():
+    lines = []
+    lines.append("=" * 80)
+    lines.append("S3 COMPATIBILITY REPORT: AWS S3 vs x2s3 Proxy")
+    lines.append("=" * 80)
+    lines.append(f"AWS:   {AWS_BUCKET}")
+    lines.append(f"Proxy: {PROXY_BUCKET}")
+    lines.append(f"Tests: {len(results)}")
+    lines.append("")
+
+    matching = [r for r in results if not r['diffs']]
+    differing = [r for r in results if r['diffs']]
+
+    lines.append(f"MATCHING:  {len(matching)}/{len(results)}")
+    lines.append(f"DIFFERENT: {len(differing)}/{len(results)}")
+    lines.append("")
+
+    # Summary table
+    lines.append("-" * 80)
+    lines.append(f"{'Test':<55} {'AWS':>5} {'Proxy':>5} {'Result':>8}")
+    lines.append("-" * 80)
+    for r in results:
+        icon = "MATCH" if not r['diffs'] else "DIFF"
+        lines.append(f"{r['name']:<55} {str(r['aws_status']):>5} {str(r['proxy_status']):>5} {icon:>8}")
+    lines.append("")
+
+    # Detailed diff section
+    if differing:
+        lines.append("=" * 80)
+        lines.append("DIFFERENCES FOUND")
+        lines.append("=" * 80)
+
+        for r in differing:
+            lines.append(f"\n### {r['name']}")
+            lines.append(f"    Category: {r['category']}")
+            lines.append(f"    Status: AWS={r['aws_status']} Proxy={r['proxy_status']} "
+                        f"(match={r['status_match']})")
+
+            for d in r['diffs']:
+                lines.append(f"    * {d}")
+
+            if r.get('aws_headers') or r.get('proxy_headers'):
+                if r['aws_headers']:
+                    lines.append(f"    AWS headers:   {json.dumps(r['aws_headers'])}")
+                if r['proxy_headers']:
+                    lines.append(f"    Proxy headers: {json.dumps(r['proxy_headers'])}")
+
+            if r['notes']:
+                lines.append(f"    Notes: {r['notes'][:500]}")
+
+    # Matching section
+    if matching:
+        lines.append("")
+        lines.append("=" * 80)
+        lines.append("MATCHING TESTS (no differences)")
+        lines.append("=" * 80)
+        for r in matching:
+            lines.append(f"  - {r['name']} (both {r['aws_status']})")
+
+    return "\n".join(lines)
+
+
+# ===========================================================================
+# Main
+# ===========================================================================
+
+if __name__ == "__main__":
+    log("Starting S3 compatibility comparison...")
+    log(f"AWS:   {AWS_BUCKET}")
+    log(f"Proxy: {PROXY_BUCKET}")
+
+    tests = [
+        test_list_v2_basic,
+        test_list_v2_delimiter,
+        test_list_v2_prefix_delimiter,
+        test_list_v2_max_keys,
+        test_list_v2_start_after,
+        test_list_v2_encoding_type,
+        test_list_v2_pagination,
+        test_list_v2_nonexistent_prefix,
+        test_list_v2_no_list_type,
+        test_list_v2_trailing_slash,
+        test_list_v2_max_keys_zero,
+        test_list_v2_max_keys_above_limit,
+        test_list_v1,
+        test_list_v2_no_delimiter_flat,
+        test_list_v2_fetch_owner,
+        test_invalid_continuation_token,
+        test_get_object_small_json,
+        test_get_object_binary,
+        test_get_object_nonexistent,
+        test_get_object_range,
+        test_get_object_range_suffix,
+        test_get_object_range_open,
+        test_get_object_range_invalid,
+        test_get_directory_no_slash,
+        test_get_directory_with_slash,
+        test_get_object_special_chars,
+        test_head_object,
+        test_head_object_nonexistent,
+        test_head_object_directory,
+        test_head_bucket,
+        test_get_bucket_acl,
+        test_nonexistent_bucket,
+        test_list_buckets,
+        test_xml_namespace,
+        test_content_type_json,
+        test_content_type_binary,
+    ]
+
+    for fn in tests:
+        try:
+            fn()
+        except Exception as e:
+            log(f"ERROR in {fn.__name__}: {e}")
+            traceback.print_exc()
+
+    report = generate_report()
+
+    report_path = "s3_comparison_report.txt"
+    with open(report_path, "w") as f:
+        f.write(report)
+
+    print("\n\n")
+    print(report)
+    print(f"\nReport saved to {report_path}")

--- a/tests/java/pom.xml
+++ b/tests/java/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.janelia</groupId>
+    <artifactId>x2s3-s3-compat-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <aws.sdk.version>2.25.60</aws.sdk.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/java/src/test/java/org/janelia/x2s3/S3CompatTest.java
+++ b/tests/java/src/test/java/org/janelia/x2s3/S3CompatTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class S3CompatTest {
 
     private static final String BUCKET = "janelia-data-examples";
-    private static final String DEFAULT_PROXY = "https://nextflow.int.janelia.org:8003";
+    private static final String DEFAULT_PROXY = "http://localhost:8000";
 
     private static S3Client awsClient;
     private static S3Client proxyClient;

--- a/tests/java/src/test/java/org/janelia/x2s3/S3CompatTest.java
+++ b/tests/java/src/test/java/org/janelia/x2s3/S3CompatTest.java
@@ -1,0 +1,320 @@
+package org.janelia.x2s3;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * S3 compatibility tests that run the same operations against both
+ * real AWS S3 and the x2s3 proxy, comparing the results.
+ *
+ * Set the PROXY_ENDPOINT environment variable to override the default proxy URL.
+ */
+public class S3CompatTest {
+
+    private static final String BUCKET = "janelia-data-examples";
+    private static final String DEFAULT_PROXY = "https://nextflow.int.janelia.org:8003";
+
+    private static S3Client awsClient;
+    private static S3Client proxyClient;
+
+    @BeforeClass
+    public static void setup() {
+        awsClient = S3Client.builder()
+                .region(Region.US_EAST_1)
+                .credentialsProvider(AnonymousCredentialsProvider.create())
+                .build();
+
+        String proxyEndpoint = System.getenv("PROXY_ENDPOINT");
+        if (proxyEndpoint == null) {
+            proxyEndpoint = DEFAULT_PROXY;
+        }
+
+        proxyClient = S3Client.builder()
+                .region(Region.US_EAST_1)
+                .endpointOverride(URI.create(proxyEndpoint))
+                .credentialsProvider(AnonymousCredentialsProvider.create())
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+    }
+
+    @Test
+    public void testListObjectsV2Basic() {
+        ListObjectsV2Request request = ListObjectsV2Request.builder()
+                .bucket(BUCKET)
+                .maxKeys(5)
+                .build();
+
+        ListObjectsV2Response awsResp = awsClient.listObjectsV2(request);
+        ListObjectsV2Response proxyResp = proxyClient.listObjectsV2(request);
+
+        assertEquals("Status should match", 200, proxyResp.sdkHttpResponse().statusCode());
+        assertEquals("Bucket name", awsResp.name(), proxyResp.name());
+        assertEquals("MaxKeys", awsResp.maxKeys(), proxyResp.maxKeys());
+        assertEquals("KeyCount", awsResp.keyCount(), proxyResp.keyCount());
+        assertEquals("IsTruncated", awsResp.isTruncated(), proxyResp.isTruncated());
+
+        // Compare object keys
+        List<S3Object> awsObjects = awsResp.contents();
+        List<S3Object> proxyObjects = proxyResp.contents();
+        assertEquals("Object count", awsObjects.size(), proxyObjects.size());
+
+        for (int i = 0; i < awsObjects.size(); i++) {
+            assertEquals("Key[" + i + "]", awsObjects.get(i).key(), proxyObjects.get(i).key());
+            assertEquals("Size[" + i + "]", awsObjects.get(i).size(), proxyObjects.get(i).size());
+            assertEquals("ETag[" + i + "]", awsObjects.get(i).eTag(), proxyObjects.get(i).eTag());
+            assertEquals("StorageClass[" + i + "]",
+                    awsObjects.get(i).storageClassAsString(),
+                    proxyObjects.get(i).storageClassAsString());
+        }
+    }
+
+    @Test
+    public void testListObjectsV2WithDelimiter() {
+        ListObjectsV2Request request = ListObjectsV2Request.builder()
+                .bucket(BUCKET)
+                .delimiter("/")
+                .build();
+
+        ListObjectsV2Response awsResp = awsClient.listObjectsV2(request);
+        ListObjectsV2Response proxyResp = proxyClient.listObjectsV2(request);
+
+        assertEquals("Delimiter", awsResp.delimiter(), proxyResp.delimiter());
+        assertEquals("CommonPrefixes count",
+                awsResp.commonPrefixes().size(),
+                proxyResp.commonPrefixes().size());
+
+        for (int i = 0; i < awsResp.commonPrefixes().size(); i++) {
+            assertEquals("CommonPrefix[" + i + "]",
+                    awsResp.commonPrefixes().get(i).prefix(),
+                    proxyResp.commonPrefixes().get(i).prefix());
+        }
+    }
+
+    @Test
+    public void testListObjectsV2WithPrefix() {
+        ListObjectsV2Request request = ListObjectsV2Request.builder()
+                .bucket(BUCKET)
+                .prefix("jrc_mus_lung_covid.n5/")
+                .delimiter("/")
+                .maxKeys(10)
+                .build();
+
+        ListObjectsV2Response awsResp = awsClient.listObjectsV2(request);
+        ListObjectsV2Response proxyResp = proxyClient.listObjectsV2(request);
+
+        assertEquals("Prefix", awsResp.prefix(), proxyResp.prefix());
+        assertEquals("KeyCount", awsResp.keyCount(), proxyResp.keyCount());
+
+        // Compare contents
+        List<S3Object> awsObjects = awsResp.contents();
+        List<S3Object> proxyObjects = proxyResp.contents();
+        assertEquals("Object count", awsObjects.size(), proxyObjects.size());
+
+        for (int i = 0; i < awsObjects.size(); i++) {
+            assertEquals("Key[" + i + "]", awsObjects.get(i).key(), proxyObjects.get(i).key());
+        }
+
+        // Compare common prefixes
+        assertEquals("CommonPrefixes count",
+                awsResp.commonPrefixes().size(),
+                proxyResp.commonPrefixes().size());
+    }
+
+    @Test
+    public void testListObjectsV2Pagination() {
+        // Page 1
+        ListObjectsV2Request req1 = ListObjectsV2Request.builder()
+                .bucket(BUCKET)
+                .delimiter("/")
+                .maxKeys(1)
+                .build();
+
+        ListObjectsV2Response awsResp1 = awsClient.listObjectsV2(req1);
+        ListObjectsV2Response proxyResp1 = proxyClient.listObjectsV2(req1);
+
+        assertEquals("Page 1 IsTruncated", awsResp1.isTruncated(), proxyResp1.isTruncated());
+        assertTrue("Should be truncated", proxyResp1.isTruncated());
+        assertNotNull("Proxy should have continuation token", proxyResp1.nextContinuationToken());
+
+        // Page 2 using each system's own token
+        ListObjectsV2Response awsResp2 = awsClient.listObjectsV2(req1.toBuilder()
+                .continuationToken(awsResp1.nextContinuationToken()).build());
+        ListObjectsV2Response proxyResp2 = proxyClient.listObjectsV2(req1.toBuilder()
+                .continuationToken(proxyResp1.nextContinuationToken()).build());
+
+        // Both page 2 results should have the same content
+        assertEquals("Page 2 key count", awsResp2.keyCount(), proxyResp2.keyCount());
+
+        // Verify we got different content than page 1
+        if (!proxyResp1.commonPrefixes().isEmpty() && !proxyResp2.commonPrefixes().isEmpty()) {
+            assertNotEquals("Pages should differ",
+                    proxyResp1.commonPrefixes().get(0).prefix(),
+                    proxyResp2.commonPrefixes().get(0).prefix());
+        }
+    }
+
+    @Test
+    public void testListObjectsV2EmptyPrefix() {
+        ListObjectsV2Request request = ListObjectsV2Request.builder()
+                .bucket(BUCKET)
+                .prefix("this-does-not-exist-xyz/")
+                .build();
+
+        ListObjectsV2Response awsResp = awsClient.listObjectsV2(request);
+        ListObjectsV2Response proxyResp = proxyClient.listObjectsV2(request);
+
+        assertEquals("KeyCount", Integer.valueOf(0), proxyResp.keyCount());
+        assertEquals("KeyCount match", awsResp.keyCount(), proxyResp.keyCount());
+        assertEquals("IsTruncated", awsResp.isTruncated(), proxyResp.isTruncated());
+        assertTrue("Contents should be empty", proxyResp.contents().isEmpty());
+    }
+
+    @Test
+    public void testListObjectsV2MaxKeysZero() {
+        ListObjectsV2Request request = ListObjectsV2Request.builder()
+                .bucket(BUCKET)
+                .maxKeys(0)
+                .build();
+
+        ListObjectsV2Response proxyResp = proxyClient.listObjectsV2(request);
+
+        assertEquals("Status", 200, proxyResp.sdkHttpResponse().statusCode());
+        assertEquals("MaxKeys", Integer.valueOf(0), proxyResp.maxKeys());
+        assertEquals("KeyCount", Integer.valueOf(0), proxyResp.keyCount());
+        assertFalse("IsTruncated should be false", proxyResp.isTruncated());
+    }
+
+    @Test
+    public void testGetObject() {
+        String key = "jrc_mus_lung_covid.n5/attributes.json";
+
+        var awsResp = awsClient.getObject(GetObjectRequest.builder()
+                .bucket(BUCKET).key(key).build());
+        var proxyResp = proxyClient.getObject(GetObjectRequest.builder()
+                .bucket(BUCKET).key(key).build());
+
+        // Compare response metadata
+        assertEquals("Content-Type",
+                awsResp.response().contentType(),
+                proxyResp.response().contentType());
+        assertEquals("Content-Length",
+                awsResp.response().contentLength(),
+                proxyResp.response().contentLength());
+        assertEquals("ETag",
+                awsResp.response().eTag(),
+                proxyResp.response().eTag());
+
+        // Compare body content
+        try {
+            byte[] awsBody = awsResp.readAllBytes();
+            byte[] proxyBody = proxyResp.readAllBytes();
+            assertArrayEquals("Body content", awsBody, proxyBody);
+        } catch (Exception e) {
+            fail("Failed to read response body: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetObjectRange() {
+        String key = "jrc_mus_lung_covid.n5/attributes.json";
+
+        var awsResp = awsClient.getObject(GetObjectRequest.builder()
+                .bucket(BUCKET).key(key).range("bytes=0-9").build());
+        var proxyResp = proxyClient.getObject(GetObjectRequest.builder()
+                .bucket(BUCKET).key(key).range("bytes=0-9").build());
+
+        assertEquals("Status", 206, proxyResp.response().sdkHttpResponse().statusCode());
+        assertEquals("Content-Length",
+                awsResp.response().contentLength(),
+                proxyResp.response().contentLength());
+        assertEquals("Content-Range",
+                awsResp.response().contentRange(),
+                proxyResp.response().contentRange());
+
+        try {
+            byte[] awsBody = awsResp.readAllBytes();
+            byte[] proxyBody = proxyResp.readAllBytes();
+            assertEquals("Body length", 10, proxyBody.length);
+            assertArrayEquals("Body content", awsBody, proxyBody);
+        } catch (Exception e) {
+            fail("Failed to read response body: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetObjectNotFound() {
+        String key = "this-key-xyz-does-not-exist-12345.txt";
+
+        try {
+            proxyClient.getObject(GetObjectRequest.builder()
+                    .bucket(BUCKET).key(key).build());
+            fail("Should have thrown NoSuchKeyException");
+        } catch (NoSuchKeyException e) {
+            assertEquals("Status", 404, e.statusCode());
+        }
+
+        try {
+            awsClient.getObject(GetObjectRequest.builder()
+                    .bucket(BUCKET).key(key).build());
+            fail("Should have thrown NoSuchKeyException");
+        } catch (NoSuchKeyException e) {
+            assertEquals("Status", 404, e.statusCode());
+        }
+    }
+
+    @Test
+    public void testHeadObject() {
+        String key = "jrc_mus_lung_covid.n5/attributes.json";
+
+        HeadObjectResponse awsResp = awsClient.headObject(HeadObjectRequest.builder()
+                .bucket(BUCKET).key(key).build());
+        HeadObjectResponse proxyResp = proxyClient.headObject(HeadObjectRequest.builder()
+                .bucket(BUCKET).key(key).build());
+
+        assertEquals("Content-Type",
+                awsResp.contentType(), proxyResp.contentType());
+        assertEquals("Content-Length",
+                awsResp.contentLength(), proxyResp.contentLength());
+        assertEquals("ETag",
+                awsResp.eTag(), proxyResp.eTag());
+        assertEquals("Last-Modified",
+                awsResp.lastModified(), proxyResp.lastModified());
+    }
+
+    @Test
+    public void testHeadObjectNotFound() {
+        String key = "this-key-xyz-does-not-exist-12345.txt";
+
+        try {
+            proxyClient.headObject(HeadObjectRequest.builder()
+                    .bucket(BUCKET).key(key).build());
+            fail("Should have thrown exception");
+        } catch (S3Exception e) {
+            assertEquals("Status", 404, e.statusCode());
+        }
+    }
+
+    @Test
+    public void testNoSuchBucket() {
+        try {
+            proxyClient.listObjectsV2(ListObjectsV2Request.builder()
+                    .bucket("this-bucket-xyz-does-not-exist-99")
+                    .build());
+            fail("Should have thrown NoSuchBucketException");
+        } catch (NoSuchBucketException e) {
+            assertEquals("Status", 404, e.statusCode());
+        }
+    }
+}

--- a/tests/test_awss3.py
+++ b/tests/test_awss3.py
@@ -55,7 +55,7 @@ def test_acl(app):
 
 def test_get_html_root(app):
     with TestClient(app) as client:
-        response = client.get("/")
+        response = client.get("/", headers={"Accept": "text/html"})
         assert response.status_code == 200
         assert response.headers['content-type'].startswith("text/html")
         for target in app.settings.targets:
@@ -67,7 +67,8 @@ def test_get_html_root(app):
 
 def test_get_html_listing(app):
     with TestClient(app) as client:
-        response = client.get("/janelia-data-examples/jrc_mus_lung_covid.n5/")
+        response = client.get("/janelia-data-examples/jrc_mus_lung_covid.n5/",
+                              headers={"Accept": "text/html"})
         assert response.status_code == 200
         assert response.headers['content-type'].startswith("text/html")
         assert '<html>' in response.text

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -38,7 +38,7 @@ def app(get_settings):
     
 def test_get_html_root(app):
     with TestClient(app) as client:
-        response = client.get("/")
+        response = client.get("/", headers={"Accept": "text/html"})
         assert response.status_code == 200
         assert response.headers['content-type'].startswith("text/html")
         for target in app.settings.targets:

--- a/x2s3/app.py
+++ b/x2s3/app.py
@@ -269,7 +269,7 @@ def create_app(settings):
                                 delimiter: Optional[str] = Query(None, alias="delimiter"),
                                 encoding_type: Optional[str] = Query(None, alias="encoding-type"),
                                 fetch_owner: Optional[bool] = Query(None, alias="fetch-owner"),
-                                max_keys: Optional[int] = Query(1000, alias="max-keys", ge=1, le=1000),
+                                max_keys: Optional[int] = Query(1000, alias="max-keys", ge=0),
                                 prefix: Optional[str] = Query(None, alias="prefix"),
                                 start_after: Optional[str] = Query(None, alias="start-after")):
 

--- a/x2s3/app.py
+++ b/x2s3/app.py
@@ -338,6 +338,10 @@ def create_app(settings):
             if client is None:
                 raise HTTPException(status_code=500, detail="Client for target bucket not found")
 
+            if not target_path:
+                # HEAD on bucket root — equivalent to HeadBucket
+                return Response(status_code=200, media_type="application/xml")
+
             return await client.head_object(target_path)
         except Exception:
             logger.opt(exception=sys.exc_info()).info("Error requesting head")

--- a/x2s3/app.py
+++ b/x2s3/app.py
@@ -248,6 +248,19 @@ def create_app(settings):
         return """User-agent: *\nDisallow: /"""
 
 
+    def _prefers_html(request: Request) -> bool:
+        """Check if the client prefers HTML over XML based on the Accept header.
+        Returns True only if text/html appears before application/xml.
+        """
+        accept = request.headers.get("accept", "")
+        html_pos = accept.find("text/html")
+        xml_pos = accept.find("application/xml")
+        if html_pos == -1:
+            return False
+        if xml_pos == -1:
+            return True
+        return html_pos < xml_pos
+
     @app.get("/{path:path}")
     async def target_dispatcher(request: Request,
                                 path: str,
@@ -266,7 +279,7 @@ def create_app(settings):
         if not target_name or (is_virtual and target_name=='www'):
             # Return target index
             bucket_list = { target: f"/{target}/" for target in app.settings.get_browseable_targets()}
-            if app.settings.ui:
+            if app.settings.ui and _prefers_html(request):
                 return templates.TemplateResponse("index.html", {"request": request, "links": bucket_list})
             else:
                 xml = get_bucket_list_xml(bucket_list)
@@ -295,13 +308,14 @@ def create_app(settings):
                 return await client.get_object(target_path, range_header)
 
         if not target_path or target_path.endswith("/"):
-            if app.settings.ui:
+            if app.settings.ui and _prefers_html(request):
                 return await browse_bucket(request, target_name, target_path,
                     continuation_token=continuation_token,
                     max_keys=100,
                     is_virtual=is_virtual)
             else:
-                return get_nosuchbucket_response(target_name)
+                return await client.list_objects_v2(continuation_token, delimiter, \
+                    encoding_type, fetch_owner, max_keys, prefix, start_after)
         else:
             range_header = request.headers.get("range")
             return await client.get_object(target_path, range_header)

--- a/x2s3/client_aioboto.py
+++ b/x2s3/client_aioboto.py
@@ -300,7 +300,7 @@ class AiobotoProxyClient(ProxyClient):
             params = {k: v for k, v in params.items() if v is not None}
 
             response = await self.client.list_objects_v2(**params)
-            next_token = remove_prefix(self.bucket_prefix, response.get("NextContinuationToken", ""))
+            next_token = remove_prefix(self.bucket_prefix, response.get("NextContinuationToken"))
             is_truncated = "true" if response.get("IsTruncated", False) else "false"
 
             contents = []

--- a/x2s3/client_aioboto.py
+++ b/x2s3/client_aioboto.py
@@ -313,7 +313,7 @@ class AiobotoProxyClient(ProxyClient):
             for obj in response.get("Contents", []):
                 contents.append({
                     'Key': remove_prefix(self.bucket_prefix, obj["Key"]),
-                    'LastModified': obj["LastModified"].isoformat(),
+                    'LastModified': obj["LastModified"].strftime("%Y-%m-%dT%H:%M:%S.000Z"),
                     'ETag': obj.get("ETag"),
                     'Size': obj.get("Size"),
                     'StorageClass': obj.get("StorageClass")

--- a/x2s3/client_aioboto.py
+++ b/x2s3/client_aioboto.py
@@ -326,7 +326,7 @@ class AiobotoProxyClient(ProxyClient):
 
             kwargs = {
                 'Name': self.target_name,
-                'Prefix': prefix,
+                'Prefix': prefix or '',
                 'Delimiter': delimiter,
                 'MaxKeys': max_keys,
                 'EncodingType': encoding_type,

--- a/x2s3/client_aioboto.py
+++ b/x2s3/client_aioboto.py
@@ -223,6 +223,12 @@ class AiobotoProxyClient(ProxyClient):
                 headers["Content-Length"] = res_headers["content-length"]
                 content_length = int(res_headers["content-length"])
 
+            if "last-modified" in res_headers:
+                headers["Last-Modified"] = res_headers["last-modified"]
+
+            if "etag" in res_headers:
+                headers["ETag"] = res_headers["etag"]
+
             return S3ObjectHandle(
                 target_name=self.target_name,
                 key=key,

--- a/x2s3/client_file.py
+++ b/x2s3/client_file.py
@@ -366,6 +366,14 @@ class FileProxyClient(ProxyClient):
         commons = set()
         contents = []
 
+        if max_keys == 0:
+            return {
+                'contents': contents,
+                'common_prefixes': commons,
+                'next_token': None,
+                'is_truncated': 'false'
+            }
+
         if os.path.isdir(path):
             started = continuation_token is None
             for root, dirs, filenames in os.walk(path):

--- a/x2s3/client_file.py
+++ b/x2s3/client_file.py
@@ -344,7 +344,7 @@ class FileProxyClient(ProxyClient):
 
             kwargs = {
                 'Name': self.target_name,
-                'Prefix': prefix,
+                'Prefix': prefix or '',
                 'Delimiter': delimiter,
                 'MaxKeys': max_keys,
                 'EncodingType': encoding_type,

--- a/x2s3/utils.py
+++ b/x2s3/utils.py
@@ -59,8 +59,13 @@ def elem_to_str(elem):
 
 def parse_xml(xml):
     """ Parse the given XML string into an XML element.
+        Strips namespace prefixes so callers can use plain tag names.
     """
-    return ET.fromstring(xml)
+    root = ET.fromstring(xml)
+    for elem in root.iter():
+        if '}' in elem.tag:
+            elem.tag = elem.tag.split('}', 1)[1]
+    return root
 
 
 def url_encode(s):
@@ -69,9 +74,12 @@ def url_encode(s):
     return urllib.parse.quote(s, safe='/ ').replace(' ','+')
 
 
+S3_XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
+
+
 def get_bucket_list_xml(buckets):
-    
-    root = ET.Element("ListAllMyBucketsResult")
+
+    root = ET.Element("ListAllMyBucketsResult", xmlns=S3_XMLNS)
     buckets_elem = add_elem(root, "Buckets")
 
     for bucket in buckets:
@@ -89,7 +97,7 @@ def get_list_xml(contents, common_prefixes, url_encode=True, **kwargs):
     if url_encode and 'EncodingType' in kwargs:
         is_url_encode = kwargs['EncodingType']=='url'
 
-    root = ET.Element("ListBucketResult")
+    root = ET.Element("ListBucketResult", xmlns=S3_XMLNS)
 
     keys = [
         'Name', 

--- a/x2s3/utils.py
+++ b/x2s3/utils.py
@@ -100,16 +100,16 @@ def get_list_xml(contents, common_prefixes, url_encode=True, **kwargs):
     root = ET.Element("ListBucketResult", xmlns=S3_XMLNS)
 
     keys = [
-        'Name', 
+        'Name',
         'Prefix',
-        'Delimiter',
-        'KeyCount',
-        'MaxKeys',
-        'EncodingType',
-        'IsTruncated',
+        'StartAfter',
         'ContinuationToken',
         'NextContinuationToken',
-        'StartAfter'
+        'KeyCount',
+        'MaxKeys',
+        'Delimiter',
+        'EncodingType',
+        'IsTruncated',
     ]
 
     for key in keys:

--- a/x2s3/utils.py
+++ b/x2s3/utils.py
@@ -44,7 +44,7 @@ def add_elem(parent, key):
 def add_telem(parent, key, value):
     """ Add a text element as a child of the given XML parent.
     """
-    if not value:
+    if value is None:
         return None
     elem = add_elem(parent, key)
     elem.text = str(value)

--- a/x2s3/utils.py
+++ b/x2s3/utils.py
@@ -145,7 +145,7 @@ def format_timestamp_s3(timestamp):
     """ Format the given timestamp to ISO date format compatible with AWS S3.
     """
     dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
-    return dt.isoformat()
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
 def format_isoformat_as_local(isodate):


### PR DESCRIPTION
This branch attempts to bring x2s3 closer into alignment with the AWS S3 API standards and conventions, for the purposes of better supporting a diverse set of clients including Java clients like N5 Viewer. 

The main change is that we now check the Accept header and return HTML or XML based on the preference. I then asked Claude to write tests of an AWS S3 bucket API, and compare to the same bucket being proxied by x2s3. It identified many small differences which have been either fixed or documented below. 

Finally, I added Java-based integration tests that run inside a Pixi environment. 

### 1. Use Accept header to determine HTML vs XML responses

When the UI is enabled, the proxy previously always returned HTML for the bucket index (`GET /`) and directory listings (`GET /bucket/prefix/`). This broke S3 API clients that expected XML.

Now the proxy checks the `Accept` header: HTML is only returned when `text/html` appears before `application/xml`. Otherwise, proper S3-compatible XML is returned (`ListAllMyBucketsResult` for the index, `ListObjectsV2` for directory listings).


### 2. Accept `max-keys=0` instead of returning 400

AWS S3 accepts `max-keys=0` and returns an empty listing with `IsTruncated=false`. The proxy was rejecting it with 400 due to Pydantic's `ge=1` constraint.

Fixed by changing the constraint to `ge=0`. Also added an early return in the file client's `walk_path` so it returns an empty listing rather than incorrectly reporting `IsTruncated=true`.


### 3. Accept `max-keys` values above 1000 instead of returning 400

AWS S3 accepts `max-keys=1001` (or higher) and simply returns up to 1000 results, echoing the requested value back in `MaxKeys`. The proxy was rejecting any value over 1000 with 400 due to Pydantic's `le=1000` constraint.

Fixed by removing the upper-bound constraint. The aioboto client passes the value through to upstream S3 which handles it naturally. The file client returns however many items are requested (no artificial cap).


### 4. Always emit `<Prefix>` and `<KeyCount>` in ListObjectsV2 XML

AWS S3 always includes `<Prefix></Prefix>` (even when empty) and `<KeyCount>0</KeyCount>` (even when zero) in ListObjectsV2 responses. The proxy was omitting these elements because `add_telem()` in `utils.py` skipped any falsy value (`""`, `0`, `None`).

Fixed by changing the guard from `if not value` to `if value is None`, so empty strings and zero are now emitted. Also fixed a related issue in the aioboto client where `NextContinuationToken` defaulted to `""` instead of `None`, which would have caused an empty `<NextContinuationToken>` element to appear on non-truncated responses. Both clients now default `Prefix` to `''` (instead of `None`) so the element is always emitted.


### 5. Include `Last-Modified` and `ETag` headers in GetObject responses

The proxy's GetObject streaming response was missing the `Last-Modified` and `ETag` headers that AWS S3 always returns. The upstream S3 response included them in `res_headers`, but `open_object()` in the aioboto client was not copying them through. (The `head_object()` method already returned these headers correctly.)


### 6. Add `xmlns` namespace to XML responses

AWS S3 includes `xmlns="http://s3.amazonaws.com/doc/2006-03-01/"` on root elements of all XML responses. The proxy was omitting it. Some S3 client libraries may depend on this namespace.

Added the namespace to `ListBucketResult` and `ListAllMyBucketsResult` root elements. Updated `parse_xml()` to strip namespace prefixes so internal XML parsing (e.g. the browse UI) continues to work with plain tag names.


### 7. Fix `LastModified` timestamp format

Proxy was returning `2024-07-26T13:39:10+00:00` (Python's `isoformat()`). AWS returns `2024-07-26T13:39:10.000Z` (milliseconds with Z suffix). Some S3 clients may parse timestamps strictly.

Fixed both the aioboto client (which called `.isoformat()` on boto datetimes) and `format_timestamp_s3()` in utils (used by the file client) to use `strftime("%Y-%m-%dT%H:%M:%S.000Z")`.


### 8. Fix XML element ordering in ListObjectsV2

Reordered the keys list in `get_list_xml()` to match AWS S3's element order: `Name, Prefix, StartAfter, ContinuationToken, NextContinuationToken, KeyCount, MaxKeys, Delimiter, EncodingType, IsTruncated`, followed by `CommonPrefixes`, then `Contents`.


### 9. Fix `HEAD /bucket` returning 500 instead of 200

`HEAD` on a bucket root (e.g. `HEAD /janelia-data-examples`) was passing an empty key to `client.head_object("")`, which failed with a 500 error. AWS returns 200 for this operation (HeadBucket).

Fixed by returning 200 with `Content-Type: application/xml` when the target path is empty, before attempting to HEAD an object.


## Remaining differences from AWS S3

These were identified during testing but intentionally not addressed.

### By design

- **ListBuckets (`GET /`)**: AWS returns 307 (requires auth); proxy returns 200 with its configured target list.
- **GetBucketAcl**: AWS returns 403 AccessDenied for anonymous requests; proxy returns a synthetic read-only ACL (200).
- **`Content-Disposition` on octet-stream files**: Proxy adds `Content-Disposition: attachment` for `application/octet-stream` files. AWS does not. 

### Not supported

- **ListObjects v1 (`list-type=1`)**: Proxy returns 400. AWS supports v1 and also uses it as the default when no `list-type` is given. Proxy always returns v2 format. 
- **`fetch-owner=true`**: AWS returns `<Owner>` elements in each `<Contents>` entry. Proxy ignores this parameter and never includes Owner data.

### Cosmetic

- **`ContinuationToken` values differ**: Expected — tokens are opaque and server-specific.
- **`Server` header**: AWS returns `AmazonS3`, proxy returns `uvicorn`.
- **XML declaration quoting**: AWS uses `<?xml version="1.0" encoding="UTF-8"?>` (double quotes, uppercase). Proxy uses single quotes and lowercase. Both are valid XML.
- **Empty element serialization**: AWS uses `<Prefix></Prefix>`, proxy uses `<Prefix />` (Python ElementTree self-closing tag). Both are semantically identical XML.
- **Error XML missing `<RequestId>` and `<HostId>`**: AWS includes these in error responses. Proxy has no real values to provide.
- **Error XML formatting**: AWS uses compact single-line XML. Proxy uses indented multi-line.
- **`binary/octet-stream` vs `application/octet-stream`**: AWS uses the non-standard `binary/octet-stream` for extensionless files. Proxy uses the IANA-standard `application/octet-stream`.
- **`x-amz-server-side-encryption`**: AWS returns this header on HeadObject. Proxy does not (it's an AWS-specific detail).
- **`x-amz-bucket-region`, `x-amz-request-id`**: AWS returns these on HeadBucket. Proxy does not.

@StephanPreibisch @cmhulbert @bogovicj @neomorphic 