### PR TITLE
Add x-amz-request-id header to all responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "x2s3"
-version = "1.2.0"
+version = "1.3.0"
 description = "RESTful web service which makes any storage system X available as an S3-compatible REST API"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -115,3 +115,29 @@ def test_get_object_missing(app):
         assert response.headers['content-type'] == "application/xml"
         root = parse_xml(response.text)
         assert root.find('Code').text == 'NoSuchKey'
+
+
+def _assert_valid_request_id(response):
+    request_id = response.headers.get('x-amz-request-id')
+    assert request_id, "missing x-amz-request-id header"
+    assert len(request_id) == 16
+    assert request_id.isalnum() and request_id.upper() == request_id
+
+
+def test_request_id_header_present(app):
+    """Every response should carry an S3-style x-amz-request-id header."""
+    with TestClient(app) as client:
+        _assert_valid_request_id(client.get("/", headers={"Accept": "text/html"}))
+        _assert_valid_request_id(client.get("/local-files?list-type=2&prefix=tests/"))
+        _assert_valid_request_id(client.head("/local-files/README.md"))
+        _assert_valid_request_id(client.get("/local-files/README.md"))
+        # Also present on error responses
+        _assert_valid_request_id(client.get("/local-files/missing"))
+
+
+def test_request_id_header_unique(app):
+    """Each request should get a distinct x-amz-request-id."""
+    with TestClient(app) as client:
+        first = client.get("/local-files/README.md").headers['x-amz-request-id']
+        second = client.get("/local-files/README.md").headers['x-amz-request-id']
+        assert first != second

--- a/x2s3/app.py
+++ b/x2s3/app.py
@@ -30,6 +30,38 @@ try:
 except ImportError:
     logger.warning("uvloop not available, using default asyncio event loop")
 
+class RequestIdMiddleware:
+    """Pure ASGI middleware that attaches an S3-style x-amz-request-id header
+    to every response.
+
+    Real S3 returns this header on all responses (GetObject, HeadObject,
+    ListObjectsV2, errors, etc.) so clients can reference a specific request
+    when correlating logs or reporting issues. We generate one id per request
+    and inject it into the response start event, which works for streaming
+    responses without buffering the body.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = generate_request_id()
+        # Expose to downstream handlers/loggers via request.state.request_id
+        scope.setdefault("state", {})["request_id"] = request_id
+
+        async def send_with_request_id(message):
+            if message["type"] == "http.response.start":
+                headers = message.setdefault("headers", [])
+                headers.append((b"x-amz-request-id", request_id.encode("latin-1")))
+            await send(message)
+
+        await self.app(scope, receive, send_with_request_id)
+
+
 def create_app(settings):
 
     @asynccontextmanager
@@ -100,13 +132,14 @@ def create_app(settings):
         logger.info("All clients closed")
 
     app = FastAPI(lifespan=lifespan)
+    app.add_middleware(RequestIdMiddleware)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
         allow_credentials=True,
         allow_methods=["GET","HEAD"],
         allow_headers=["*"],
-        expose_headers=["Range", "Content-Range"],
+        expose_headers=["Range", "Content-Range", "x-amz-request-id"],
     )
     app.mount("/static", StaticFiles(directory="static"), name="static")
     templates = Jinja2Templates(directory="templates")

--- a/x2s3/utils.py
+++ b/x2s3/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import secrets
 import urllib
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
@@ -75,6 +76,17 @@ def url_encode(s):
 
 
 S3_XMLNS = "http://s3.amazonaws.com/doc/2006-03-01/"
+
+# Characters used by AWS S3 for the x-amz-request-id value (uppercase alphanumeric).
+_REQUEST_ID_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+
+def generate_request_id(length=16):
+    """ Generate an S3-style request id: a short uppercase alphanumeric string.
+        Used as the value of the x-amz-request-id response header so clients can
+        reference a specific request when correlating logs or reporting issues.
+    """
+    return ''.join(secrets.choice(_REQUEST_ID_ALPHABET) for _ in range(length))
 
 
 def get_bucket_list_xml(buckets):


### PR DESCRIPTION
## Summary

Real S3 returns an `x-amz-request-id` header on every response (`GetObject`, `HeadObject`, `ListObjectsV2`, errors) so clients can reference a specific request when correlating logs or reporting issues. This adds the same to x2s3.

Verified against `s3://janelia-data-examples`: the header is a 16-char uppercase-alphanumeric string, unique per request, present on success and error responses alike.

## Changes

- **`x2s3/utils.py`** — `generate_request_id()` produces an S3-style 16-char uppercase-alphanumeric id via `secrets`.
- **`x2s3/app.py`** — `RequestIdMiddleware`, a **pure-ASGI** middleware that generates one id per request and injects the header on the `http.response.start` event. Pure ASGI (rather than `BaseHTTPMiddleware`) is deliberate: it does not re-wrap the response body, so it leaves the app's streaming/cancellation logic in `S3Stream` and `file_iterator` untouched. The id is also stashed on `scope["state"]["request_id"]` for log correlation. `x-amz-request-id` added to CORS `expose_headers` so browser clients (Neuroglancer/N5/Vizarr) can read it.
- **`tests/test_file.py`** — assertions that the header is present and well-formed on HTML root, list, HEAD, GET, and 404 responses, plus a uniqueness check.
- **`pyproject.toml`** — version bump to 1.3.0.

A single middleware covers all response paths (success, streaming, errors, templates, static), so no per-client changes were needed.


@StephanPreibisch @cmhulbert @bogovicj