### PR TITLE
fix: send Vary: Accept on content-negotiated responses

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         max-size: "128m"
 
   x2s3:
-    image: ghcr.io/janeliascicomp/x2s3:1.4.1
+    image: ghcr.io/janeliascicomp/x2s3:1.4.2
     container_name: x2s3
     restart: unless-stopped
     ports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "x2s3"
-version = "1.4.1"
+version = "1.4.2"
 description = "RESTful web service which makes any storage system X available as an S3-compatible REST API"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -54,6 +54,17 @@ def test_get_html_root(app):
                 assert target.name not in response.text
 
 
+def test_vary_accept_header(app):
+    # HTML vs XML is negotiated on Accept, so caches must key on it
+    with TestClient(app) as client:
+        for path in ["/", "/local-files/"]:
+            for accept in ["text/html", "application/xml"]:
+                response = client.get(path, headers={"Accept": accept})
+                assert response.status_code == 200
+                assert response.headers['vary'] == "Accept"
+                assert response.headers['content-type'].startswith(accept)
+
+
 def test_list_objects(app):
     with TestClient(app) as client:
         bucket_name = 'local-files'

--- a/x2s3/app.py
+++ b/x2s3/app.py
@@ -364,10 +364,14 @@ def create_app(settings):
             # Return target index
             bucket_list = { target: f"/{target}/" for target in app.settings.get_browseable_targets()}
             if app.settings.ui and _prefers_html(request):
-                return templates.TemplateResponse(request, "index.html", context={"links": bucket_list})
+                response = templates.TemplateResponse(request, "index.html", context={"links": bucket_list})
             else:
                 xml = get_bucket_list_xml(bucket_list)
-                return Response(content=xml, status_code=200, media_type="application/xml")
+                response = Response(content=xml, status_code=200, media_type="application/xml")
+            # Same URL serves HTML or XML depending on Accept, so shared
+            # caches must store the two variants separately
+            response.headers["Vary"] = "Accept"
+            return response
         
         target_config = app.settings.get_target_config(target_name)
         if not target_config:
@@ -408,13 +412,15 @@ def create_app(settings):
             if not target_config.browseable:
                 return get_accessdenied_response()
             if app.settings.ui and _prefers_html(request):
-                return await browse_bucket(request, target_name, target_path,
+                response = await browse_bucket(request, target_name, target_path,
                     continuation_token=continuation_token,
                     max_keys=100,
                     is_virtual=is_virtual)
             else:
-                return await client.list_objects_v2(continuation_token, delimiter, \
+                response = await client.list_objects_v2(continuation_token, delimiter, \
                     encoding_type, fetch_owner, max_keys, prefix, start_after)
+            response.headers["Vary"] = "Accept"
+            return response
         else:
             return await get_object_or_denied(target_path)
 


### PR DESCRIPTION
## Problem

In production, the initial browser load of the index page often shows the ListBuckets XML instead of the HTML index; reloading then shows the HTML. Not reproducible in local deployments.

## Root cause

The index (`/`) and bucket browse (`/{bucket}/`) URLs serve either HTML or XML for the same URL, negotiated purely on the `Accept` header, but the responses never set `Vary: Accept`. The production nginx `proxy_cache` keys only on scheme/host/method/URI, so whichever variant is requested first after cache expiry is cached and served to everyone for 15 minutes. S3 clients (aws cli, neuroglancer, monitors) frequently hit `/` for ListBuckets without `text/html` in their Accept header, poisoning the cache with XML for browsers. A hard reload sends `Cache-Control: no-cache`, which the nginx config maps to `proxy_cache_bypass`, refreshing the entry with HTML — hence "reload fixes it".

Local deployments have no shared cache in front, so the bug never appears there.

## Fix

Set `Vary: Accept` on both variants at the two negotiated fork points in `target_dispatcher`. nginx's proxy cache honors upstream `Vary` by default (since 1.7.7), so HTML and XML variants are now cached separately with no nginx changes required.

## Testing

Added `test_vary_accept_header` covering both paths × both Accept types. Full suite: 71 passed.

@StephanPreibisch @allison-truhlar