### PR TITLE
fix: return 200 from HEAD on the proxy root index

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -106,6 +106,20 @@ def test_head_object(app):
         assert response.status_code == 404
 
 
+def test_head_root_index(app):
+    # The root index exists for GET, so HEAD must not report NoSuchBucket
+    with TestClient(app) as client:
+        for accept in ["text/html", "application/xml"]:
+            head_response = client.head("/", headers={"Accept": accept})
+            assert head_response.status_code == 200
+            assert head_response.headers['content-type'].startswith(accept)
+            assert head_response.headers['vary'] == "Accept"
+            # RFC 9110: HEAD sends the header fields GET would have sent
+            get_response = client.get("/", headers={"Accept": accept})
+            assert get_response.status_code == head_response.status_code
+            assert get_response.headers['content-type'] == head_response.headers['content-type']
+
+
 def test_get_object(app):
     with TestClient(app) as client:
         response = client.get("/local-files/README.md")

--- a/x2s3/app.py
+++ b/x2s3/app.py
@@ -420,12 +420,21 @@ def create_app(settings):
 
 
 
-    @app.head("{path:path}")
+    @app.head("/{path:path}")
     async def head_object(request: Request, path: str):
 
-        target_name, target_path, _ = get_target(request, path)
-        if not target_name:
-            return get_nosuchbucket_response('')
+        target_name, target_path, is_virtual = get_target(request, path)
+
+        if not target_name or (is_virtual and target_name=='www'):
+            # target_dispatcher serves the proxy index for GET here, so HEAD
+            # must report the same status and headers, just without the body
+            media_type = "text/html" if app.settings.ui and _prefers_html(request) \
+                else "application/xml"
+            response = Response(status_code=200, media_type=media_type)
+            # Same URL serves HTML or XML depending on Accept, so shared
+            # caches must store the two variants separately
+            response.headers["Vary"] = "Accept"
+            return response
 
         try:
             target_config = app.settings.get_target_config(target_name)


### PR DESCRIPTION
## Problem

`HEAD /` returns `404 NoSuchBucket` while `GET /` returns the `200` index page for the same URL:

```console
$ curl -sSI https://s3.janelia.org/
HTTP/2 404
content-type: application/xml
content-length: 174

$ curl -sS -o /dev/null -w '%{http_code} %{content_type}\n' https://s3.janelia.org/
200 text/html; charset=utf-8
```

Reproduces on HTTP/1.1, with browser `User-Agent`/`Accept` headers, and directly against the backend, so it is the app and not nginx or HTTP/2.

The 404 body is a `NoSuchBucket` error with an *empty* bucket name. Byte math confirms it — a bucket name of 30 characters yields 204 bytes, and `204 - 30 = 174`:

```console
$ curl -sS https://s3.janelia.org/definitely-not-a-bucket-xyz123   # content-length: 204
<Error><Code>NoSuchBucket</Code>...<BucketName>definitely-not-a-bucket-xyz123</BucketName></Error>
```

## Root cause

`target_dispatcher` (GET) special-cases an empty target name as "serve the proxy index":

```python
if not target_name or (is_virtual and target_name=='www'):
    # Return target index
```

`head_object` has no such case, so the same empty target name falls into the missing-bucket path:

```python
target_name, target_path, _ = get_target(request, path)
if not target_name:
    return get_nosuchbucket_response('')
```

The two handlers therefore disagree about whether `/` exists. RFC 9110 §9.3.2 requires HEAD to return the same status and header fields GET would have sent.

## Fix

Mirror `target_dispatcher`'s root condition in `head_object`, including the virtual `www` host, and reply `200` with the media type `Accept` would have negotiated — `_prefers_html` is reused so HEAD and GET cannot drift apart.

`Vary: Accept` is set for the same reason as #23 / #24: `/` serves two representations, and nginx's `proxy_cache` stores HEAD responses too, so the variants must be kept apart. That PR covers the GET fork points; HEAD is outside its scope, and the two do not overlap textually.

The route path also gains its missing leading slash so it matches the GET route. `get_target` already does `removeprefix('/')`, so that part is behavior-neutral.

## Testing

`test_head_root_index` asserts the status, the negotiated content type, and `Vary` for both `Accept` types, and compares HEAD's status and content type against GET's on the same URL. Verified it fails without the app change (`assert 404 == 200`) and passes with it.

Full suite: **71 passed**.

## Out of scope

`HEAD /{bucket}/` returns `content-type: application/xml` unconditionally, even though `GET /{bucket}/` serves HTML to browsers. Pre-existing and untested, so left alone here — happy to follow up if you want HEAD to negotiate there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
