### PR TITLE
fix: negotiate HEAD content type on bucket root

### DIFF
--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -131,6 +131,19 @@ def test_head_root_index(app):
             assert get_response.headers['content-type'] == head_response.headers['content-type']
 
 
+def test_head_bucket_root_index(app):
+    # GET /{bucket}/ negotiates browse HTML vs XML listing; HEAD must match
+    with TestClient(app) as client:
+        for accept in ["text/html", "application/xml"]:
+            head_response = client.head("/local-files/", headers={"Accept": accept})
+            assert head_response.status_code == 200
+            assert head_response.headers['content-type'].startswith(accept)
+            assert head_response.headers['vary'] == "Accept"
+            get_response = client.get("/local-files/", headers={"Accept": accept})
+            assert get_response.status_code == head_response.status_code
+            assert get_response.headers['content-type'] == head_response.headers['content-type']
+
+
 def test_get_object(app):
     with TestClient(app) as client:
         response = client.get("/local-files/README.md")

--- a/x2s3/app.py
+++ b/x2s3/app.py
@@ -456,7 +456,12 @@ def create_app(settings):
                 # requires s3:ListBucket in real S3
                 if not target_config.browseable:
                     return Response(status_code=403, media_type="application/xml")
-                return Response(status_code=200, media_type="application/xml")
+                # GET serves the browse UI or an XML listing here depending
+                # on Accept, so HEAD must report the matching content type
+                media_type = "text/html" if app.settings.ui and _prefers_html(request) \
+                    else "application/xml"
+                return Response(status_code=200, media_type=media_type,
+                    headers={"Vary": "Accept"})
 
             response = await client.head_object(target_path)
             if response.status_code == 404 and not target_config.browseable:


### PR DESCRIPTION
## Problem

Follow-up to the item noted as out-of-scope in #25: `HEAD /{bucket}/` returns `content-type: application/xml` unconditionally, while `GET /{bucket}/` negotiates on `Accept` and serves the browse UI (`text/html`) to browsers. Per RFC 9110 §9.3.2, HEAD should report the same headers GET would have sent.

## Fix

In `head_object`'s bucket-root branch, negotiate the content type with the same `_prefers_html()` helper GET uses, and set `Vary: Accept` since the response now varies on it (same reasoning as #24/#25 — the nginx proxy cache stores HEAD responses too).

The unbrowseable 403 path is unchanged, matching GET's non-negotiated `AccessDenied` response.

`HEAD /{bucket}/subdir/` is left alone: it maps to HeadObject on the key and 404s (tested behavior in `test_head_object`), which matches real S3 semantics even though GET serves a listing there.

## Testing

Added `test_head_bucket_root_index` mirroring `test_head_root_index`: asserts status, negotiated content type, and `Vary` for both `Accept` types, and compares HEAD against GET on the same URL. Verified it fails without the app change and passes with it.

Full suite: **73 passed**.

@StephanPreibisch @neomorphic 